### PR TITLE
Improve retry on InvalidSessionException

### DIFF
--- a/README.md
+++ b/README.md
@@ -651,7 +651,11 @@ For more information about how to use the driver for Java, please read the [Gett
 
 # Release Notes
 
-### Release 1.0.1 (September 10, 2019)
+### Release 1.0.2
+- Bump version of the AWS SDK to 11.1.649
+- Fix an issue that will make the driver throw an `InvalidSessionException` when executing a transaction. In the initial release of the driver, if a session becomes invalid while using the `PooledQldbSession`'s `execute` convenience methods, then the transaction will fail completely for the caller, as the `InvalidSessionException` is re-thrown. To prevent the caller from needing to write additional retry logic, the `execute` methods will now transparently replace an invalid session with a new one and retry the transaction but still be limited to the number of retries configured.
+
+### Release 1.0.1
 - Version 1.0.1 of the Amazon QLDB Driver for Java.
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>software.amazon.qldb</groupId>
     <artifactId>amazon-qldb-driver-java</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
@@ -67,19 +67,19 @@
         <maven.build.timestamp.format>yyyy</maven.build.timestamp.format>
         <build.year>${maven.build.timestamp}</build.year>
         <jdkVersion>1.8</jdkVersion>
-        <awssdk.version>1.11.576</awssdk.version>
+        <awssdk.version>1.11.649</awssdk.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-qldbsession</artifactId>
-            <version>1.11.628</version>
+            <version>${awssdk.version}</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-core</artifactId>
-            <version>1.11.628</version>
+            <version>${awssdk.version}</version>
         </dependency>
         <dependency>
             <groupId>com.amazon.ion</groupId>

--- a/src/main/java/software/amazon/qldb/BaseQldbDriver.java
+++ b/src/main/java/software/amazon/qldb/BaseQldbDriver.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package software.amazon.qldb;
+
+import com.amazon.ion.IonSystem;
+import com.amazonaws.services.qldbsession.AmazonQLDBSession;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Represents a base class for a factory that creates sessions.
+ */
+abstract class BaseQldbDriver {
+    protected final String ledgerName;
+    protected final AmazonQLDBSession amazonQldbSession;
+    protected final int retryLimit;
+    protected final IonSystem ionSystem;
+    protected final AtomicBoolean isClosed;
+
+    /**
+     * Constructor for the base abstract class of a factory for creating sessions.
+     *
+     * @param ledgerName
+     *                  The ledger to create sessions to.
+     * @param amazonQLDBSession
+     *                  The low-level session used for communication with QLDB.
+     * @param retryLimit
+     *                  The amount of retries sessions created by this driver will attempt upon encountering a non-fatal
+     *                  error.
+     * @param ionSystem
+     *                  The {@link IonSystem} sessions created by this driver will use.
+     */
+    protected BaseQldbDriver(String ledgerName, AmazonQLDBSession amazonQLDBSession, int retryLimit,
+                             IonSystem ionSystem) {
+        this.ledgerName = ledgerName;
+        this.amazonQldbSession = amazonQLDBSession;
+        this.retryLimit = retryLimit;
+        this.ionSystem = ionSystem;
+        this.isClosed = new AtomicBoolean(false);
+    }
+}

--- a/src/main/java/software/amazon/qldb/BaseQldbDriverBuilder.java
+++ b/src/main/java/software/amazon/qldb/BaseQldbDriverBuilder.java
@@ -1,10 +1,10 @@
 /*
- * Copyright 2014-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at
  *
- * http://aws.amazon.com/apache2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
  * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
@@ -12,15 +12,15 @@
  */
 package software.amazon.qldb;
 
-import java.util.MissingResourceException;
-import java.util.ResourceBundle;
-
 import com.amazon.ion.IonSystem;
 import com.amazon.ion.system.IonSystemBuilder;
 import com.amazonaws.ClientConfigurationFactory;
 import com.amazonaws.services.qldbsession.AmazonQLDBSession;
 import com.amazonaws.services.qldbsession.AmazonQLDBSessionClientBuilder;
 import com.amazonaws.util.ValidationUtils;
+
+import java.util.MissingResourceException;
+import java.util.ResourceBundle;
 
 abstract class BaseQldbDriverBuilder<Subclass extends BaseQldbDriverBuilder, TypeToBuild> {
     private static final String VERSION_KEY = "project.version";
@@ -73,7 +73,8 @@ abstract class BaseQldbDriverBuilder<Subclass extends BaseQldbDriverBuilder, Typ
     }
 
     /**
-     * Specify the retry limit that any convenience execute methods provided by sessions created from the driver will attempt.
+     * Specify the retry limit that any convenience execute methods provided by sessions created from the driver will
+     * attempt.
      *
      * @param retryLimit
      *              The number of retry attempts to be made by the session.
@@ -119,13 +120,6 @@ abstract class BaseQldbDriverBuilder<Subclass extends BaseQldbDriverBuilder, Typ
     }
 
     /**
-     * Retrieve the version string for the driver.
-     *
-     * @return The version string for the driver.
-     */
-    protected abstract String getVersion();
-
-    /**
      * Create a new driver instance using the current configuration.
      *
      * @return The newly created driver instance.
@@ -140,4 +134,11 @@ abstract class BaseQldbDriverBuilder<Subclass extends BaseQldbDriverBuilder, Typ
     protected Subclass getSubclass() {
         return (Subclass) this;
     }
+
+    /**
+     * Retrieve the version string for the driver.
+     *
+     * @return The version string for the driver.
+     */
+    protected abstract String getVersion();
 }

--- a/src/main/java/software/amazon/qldb/BaseQldbSession.java
+++ b/src/main/java/software/amazon/qldb/BaseQldbSession.java
@@ -1,10 +1,10 @@
 /*
- * Copyright 2014-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at
  *
- * http://aws.amazon.com/apache2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
  * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
@@ -12,15 +12,12 @@
  */
 package software.amazon.qldb;
 
-import java.util.concurrent.atomic.AtomicBoolean;
-
+import com.amazon.ion.IonSystem;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.amazon.ion.IonSystem;
-import com.amazonaws.AmazonClientException;
-
 import software.amazon.qldb.exceptions.Errors;
+
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * The abstract base session to a specific ledger within QLDB, containing the properties and methods shared by the
@@ -30,10 +27,11 @@ abstract class BaseQldbSession {
     private static final Logger logger = LoggerFactory.getLogger(BaseQldbSession.class);
     private static final long SLEEP_BASE_MS = 10;
     private static final long SLEEP_CAP_MS = 5000;
-    static final String TABLE_NAME_QUERY = "SELECT VALUE name FROM information_schema.user_tables WHERE status = 'ACTIVE'";
+    static final String TABLE_NAME_QUERY =
+            "SELECT VALUE name FROM information_schema.user_tables WHERE status = 'ACTIVE'";
 
     final int retryLimit;
-    final Session session;
+    Session session;
     final AtomicBoolean isClosed = new AtomicBoolean(true);
     final IonSystem ionSystem;
 
@@ -42,15 +40,6 @@ abstract class BaseQldbSession {
         this.ionSystem = ionSystem;
         this.session = session;
         this.isClosed.set(false);
-    }
-
-    /**
-     * Determine if the driver's sessions are closed.
-     *
-     * @return {@code true} if the sessions are closed; {@code false} otherwise.
-     */
-    public boolean isClosed() {
-        return isClosed.get();
     }
 
     /**
@@ -72,43 +61,12 @@ abstract class BaseQldbSession {
     }
 
     /**
-     * Determine if the session is alive by sending an abort message. Will close the session if the abort is
-     * unsuccessful.
+     * Determine if the driver's sessions are closed.
      *
-     * This should only be used when the session is known to not be in use, otherwise the state will be abandoned.
-     *
-     * @return {@code true} if the session was aborted successfully; {@code false} if the session is closed.
+     * @return {@code true} if the sessions are closed; {@code false} otherwise.
      */
-    boolean abortOrClose() {
-        if (isClosed.get()) {
-            return false;
-        }
-        try {
-            session.sendAbort();
-            return true;
-        } catch (AmazonClientException e) {
-            isClosed.set(true);
-            return false;
-        }
-    }
-
-    /**
-     * Mark the session as closed.
-     */
-    void softClose() {
-        isClosed.set(true);
-    }
-
-    /**
-     * Check and throw if the session is closed.
-     *
-     * @throws IllegalStateException if the session is closed.
-     */
-    void throwIfClosed() {
-        if (isClosed.get()) {
-            logger.error(Errors.SESSION_CLOSED.get());
-            throw new IllegalStateException(Errors.SESSION_CLOSED.get());
-        }
+    public boolean isClosed() {
+        return isClosed.get();
     }
 
     /**
@@ -127,6 +85,18 @@ abstract class BaseQldbSession {
         } catch (InterruptedException e) {
             // Reset the interruption flag.
             Thread.currentThread().interrupt();
+        }
+    }
+
+    /**
+     * Check and throw if the session is closed.
+     *
+     * @throws IllegalStateException if the session is closed.
+     */
+    void throwIfClosed() {
+        if (isClosed.get()) {
+            logger.error(Errors.SESSION_CLOSED.get());
+            throw new IllegalStateException(Errors.SESSION_CLOSED.get());
         }
     }
 }

--- a/src/main/java/software/amazon/qldb/BaseResult.java
+++ b/src/main/java/software/amazon/qldb/BaseResult.java
@@ -1,10 +1,10 @@
 /*
- * Copyright 2014-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at
  *
- * http://aws.amazon.com/apache2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
  * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
@@ -15,8 +15,8 @@ package software.amazon.qldb;
 import com.amazon.ion.IonSystem;
 
 /**
- * The abstract base result, containing the properties and methods shared by the asynchronous and synchronous implementations of
- * the result of executing a statement in QLDB.
+ * The abstract base result, containing the properties and methods shared by the asynchronous and synchronous
+ * implementations of the result of executing a statement in QLDB.
  */
 abstract class BaseResult {
     final Session session;

--- a/src/main/java/software/amazon/qldb/BaseSyncQldbDriver.java
+++ b/src/main/java/software/amazon/qldb/BaseSyncQldbDriver.java
@@ -1,10 +1,10 @@
 /*
- * Copyright 2014-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at
  *
- * http://aws.amazon.com/apache2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
  * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
@@ -12,49 +12,41 @@
  */
 package software.amazon.qldb;
 
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.atomic.AtomicBoolean;
-
 import com.amazon.ion.IonSystem;
 import com.amazonaws.services.qldbsession.AmazonQLDBSession;
+
+import java.util.concurrent.ExecutorService;
 
 /**
  * Represents a base class for a factory for creating synchronous sessions.
  */
-abstract class BaseSyncQldbDriver implements AutoCloseable {
+abstract class BaseSyncQldbDriver extends BaseQldbDriver implements AutoCloseable {
     protected final int readAhead;
-    protected final String ledgerName;
-    protected final int retryLimit;
-    protected final AmazonQLDBSession amazonQldbSession;
-    protected final IonSystem ionSystem;
     protected final ExecutorService executorService;
-    protected final AtomicBoolean isClosed;
 
     /**
      * Constructor for the base abstract class of a factory for creating synchronous sessions.
      *
      * @param ledgerName
      *                  The ledger to create sessions to.
-     * @param client
+     * @param amazonQLDBSession
      *                  The low-level session used for communication with QLDB.
      * @param retryLimit
-     *                  The amount of retries sessions created by this driver will attempt upon encountering a non-fatal error.
+     *                  The amount of retries sessions created by this driver will attempt upon encountering a non-fatal
+     *                  error.
      * @param readAhead
-     *                  The number of read-ahead buffers for each open result set created from sessions from this driver.
+     *                  The number of read-ahead buffers for each open result set created from sessions from this
+     *                  driver.
      * @param ionSystem
      *                  The {@link IonSystem} sessions created by this driver will use.
      * @param executorService
      *                  The executor to be used by the retrieval thread if read-ahead is enabled.
      */
-    protected BaseSyncQldbDriver(String ledgerName, AmazonQLDBSession client, int retryLimit, int readAhead,
+    protected BaseSyncQldbDriver(String ledgerName, AmazonQLDBSession amazonQLDBSession, int retryLimit, int readAhead,
                                  IonSystem ionSystem, ExecutorService executorService) {
-        this.ledgerName = ledgerName;
-        this.amazonQldbSession = client;
-        this.retryLimit = retryLimit;
+        super(ledgerName, amazonQLDBSession, retryLimit, ionSystem);
         this.readAhead = readAhead;
-        this.ionSystem = ionSystem;
         this.executorService = executorService;
-        this.isClosed = new AtomicBoolean(false);
     }
 
     @Override

--- a/src/main/java/software/amazon/qldb/BaseSyncQldbDriverBuilder.java
+++ b/src/main/java/software/amazon/qldb/BaseSyncQldbDriverBuilder.java
@@ -1,10 +1,10 @@
 /*
- * Copyright 2014-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at
  *
- * http://aws.amazon.com/apache2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
  * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
@@ -12,9 +12,9 @@
  */
 package software.amazon.qldb;
 
-import java.util.concurrent.ExecutorService;
-
 import com.amazonaws.util.ValidationUtils;
+
+import java.util.concurrent.ExecutorService;
 
 /**
  * Base builder object for creating synchronous drivers, allowing for configuration of the parameters
@@ -34,7 +34,8 @@ abstract class BaseSyncQldbDriverBuilder<B extends BaseSyncQldbDriverBuilder, T 
 
     /**
      * Specify the number of read-ahead buffers, determining the amount of sets of results buffered in memory,
-     * for each open result set, created within the driver. If read-ahead is desired to be enabled, this must be set to at least 2.
+     * for each open result set, created within the driver. If read-ahead is desired to be enabled, this must be set to
+     * at least 2.
      *
      * The higher the read-ahead buffer count, the more memory will be consumed by the driver when retrieving results.
      *

--- a/src/main/java/software/amazon/qldb/BufferedResult.java
+++ b/src/main/java/software/amazon/qldb/BufferedResult.java
@@ -1,10 +1,10 @@
 /*
- * Copyright 2014-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at
  *
- * http://aws.amazon.com/apache2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
  * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
@@ -12,12 +12,12 @@
  */
 package software.amazon.qldb;
 
+import com.amazon.ion.IonValue;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
-
-import com.amazon.ion.IonValue;
 
 /**
  * Implementation of a result which buffers all values in memory, rather than stream them from QLDB during retrieval.

--- a/src/main/java/software/amazon/qldb/Executor.java
+++ b/src/main/java/software/amazon/qldb/Executor.java
@@ -1,10 +1,10 @@
 /*
- * Copyright 2014-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at
  *
- * http://aws.amazon.com/apache2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
  * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions

--- a/src/main/java/software/amazon/qldb/ExecutorNoReturn.java
+++ b/src/main/java/software/amazon/qldb/ExecutorNoReturn.java
@@ -1,10 +1,10 @@
 /*
- * Copyright 2014-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at
  *
- * http://aws.amazon.com/apache2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
  * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions

--- a/src/main/java/software/amazon/qldb/PooledQldbSession.java
+++ b/src/main/java/software/amazon/qldb/PooledQldbSession.java
@@ -1,10 +1,10 @@
 /*
- * Copyright 2014-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at
  *
- * http://aws.amazon.com/apache2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
  * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
@@ -12,16 +12,15 @@
  */
 package software.amazon.qldb;
 
-import java.util.List;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Supplier;
-
 import com.amazon.ion.IonValue;
 import com.amazonaws.annotation.NotThreadSafe;
-import com.amazonaws.services.qldbsession.model.InvalidSessionException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.qldb.exceptions.Errors;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
 
 /**
  * Represents a pooled session object. See {@link QldbSessionImpl} for more details.
@@ -90,14 +89,12 @@ final class PooledQldbSession implements QldbSession {
 
     @Override
     public String getLedgerName() {
-        throwIfClosed();
-        return session.getLedgerName();
+        return invokeOnSession(session::getLedgerName);
     }
 
     @Override
     public String getSessionToken() {
-        throwIfClosed();
-        return session.getSessionToken();
+        return invokeOnSession(session::getSessionToken);
     }
 
     @Override
@@ -111,6 +108,20 @@ final class PooledQldbSession implements QldbSession {
     }
 
     /**
+     * Handle method calls using the internal {@link QldbSessionImpl} this object wraps.
+     *
+     * @param sessionFunction
+     *                      The function to call on the session.
+     *
+     * @return The result of the function call to the session.
+     * @throws IllegalStateException if this session is closed.
+     */
+    private <T extends Object> T invokeOnSession(Supplier<T> sessionFunction) {
+        throwIfClosed();
+        return sessionFunction.get();
+    }
+
+    /**
      * Check and throw if this session is closed.
      *
      * @throws IllegalStateException if this session is closed.
@@ -119,26 +130,6 @@ final class PooledQldbSession implements QldbSession {
         if (isClosed.get()) {
             logger.error(Errors.SESSION_CLOSED.get());
             throw new IllegalStateException(Errors.SESSION_CLOSED.get());
-        }
-    }
-
-    /**
-     * Handle method calls using the internal {@link QldbSessionImpl} this object wraps.
-     *
-     * @param sessionFunction
-     *                      The function to call on the session.
-     *
-     * @return The result of the function call to the session.
-     * @throws IllegalStateException if this session is closed.
-     * @throws InvalidSessionException if the {@link Session} to QLDB used by this session is invalid.
-     */
-    private <T extends Object> T invokeOnSession(Supplier<T> sessionFunction) {
-        throwIfClosed();
-        try {
-            return sessionFunction.get();
-        } catch (InvalidSessionException ise) {
-            close();
-            throw ise;
         }
     }
 }

--- a/src/main/java/software/amazon/qldb/QldbDriver.java
+++ b/src/main/java/software/amazon/qldb/QldbDriver.java
@@ -1,10 +1,10 @@
 /*
- * Copyright 2014-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at
  *
- * http://aws.amazon.com/apache2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
  * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
@@ -12,24 +12,23 @@
  */
 package software.amazon.qldb;
 
-import java.util.concurrent.ExecutorService;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.amazon.ion.IonSystem;
 import com.amazonaws.annotation.ThreadSafe;
 import com.amazonaws.services.qldbsession.AmazonQLDBSession;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import software.amazon.qldb.exceptions.Errors;
 
+import java.util.concurrent.ExecutorService;
+
 /**
- * <p>Represents a factory for accessing sessions to a specific ledger within QLDB. This class or {@link PooledQldbDriver} should be
- * the main entry points to any interaction with QLDB. {@link #getSession()} will create a {@link QldbSession} to the specified
- * ledger within QLDB as a communication channel. Any sessions acquired should be cleaned up with {@link QldbSession#close()} to
- * free up resources.</p>
+ * <p>Represents a factory for accessing sessions to a specific ledger within QLDB. This class or
+ * {@link PooledQldbDriver} should be the main entry points to any interaction with QLDB. {@link #getSession()} will
+ * create a {@link QldbSession} to the specified ledger within QLDB as a communication channel. Any sessions acquired
+ * should be cleaned up with {@link QldbSession#close()} to free up resources.</p>
  *
- * <p>This factory does not attempt to re-use or manage sessions in any way. It is recommended to use {@link PooledQldbDriver} for
- * both less resource usage and lower latency.</p>
+ * <p>This factory does not attempt to re-use or manage sessions in any way. It is recommended to use
+ * {@link PooledQldbDriver} for both less resource usage and lower latency.</p>
  */
 @ThreadSafe
 public class QldbDriver extends BaseSyncQldbDriver {
@@ -76,7 +75,7 @@ public class QldbDriver extends BaseSyncQldbDriver {
         /**
          * Restricted constructor. Use {@link #builder()} to retrieve an instance of this class.
          */
-        QldbDriverBuilder() {}
+        protected QldbDriverBuilder() {}
 
         @Override
         protected QldbDriver createDriver() {

--- a/src/main/java/software/amazon/qldb/QldbSession.java
+++ b/src/main/java/software/amazon/qldb/QldbSession.java
@@ -1,10 +1,10 @@
 /*
- * Copyright 2014-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at
  *
- * http://aws.amazon.com/apache2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
  * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
@@ -12,39 +12,40 @@
  */
 package software.amazon.qldb;
 
-import java.util.List;
-
 import com.amazon.ion.IonValue;
 import com.amazonaws.annotation.NotThreadSafe;
 import com.amazonaws.services.qldbsession.model.OccConflictException;
-
 import software.amazon.qldb.exceptions.AbortException;
 
+import java.util.List;
+
 /**
- * <p>The top-level interface for a QldbSession object for interacting with QLDB. A QldbSession is linked to the specified ledger in
- * the parent driver of the instance of the QldbSession. In any given QldbSession, only one transaction can be active at a time.
- * This object can have only one underlying session to QLDB, and therefore the lifespan of a QldbSession is tied to the underlying
- * session, which is not indefinite, and on expiry this QldbSession will become invalid, and a new QldbSession needs to be created
- * from the parent driver in order to continue usage.</p>
+ * <p>The top-level interface for a QldbSession object for interacting with QLDB. A QldbSession is linked to the
+ * specified ledger in the parent driver of the instance of the QldbSession. In any given QldbSession, only one
+ * transaction can be active at a time. This object can have only one underlying session to QLDB, and therefore the
+ * lifespan of a QldbSession is tied to the underlying session, which is not indefinite, and on expiry this QldbSession
+ * will become invalid, and a new QldbSession needs to be created from the parent driver in order to continue usage.</p>
  *
  * <p>When a QldbSession is no longer needed, {@link #close()} should be invoked in order to clean up any resources.</p>
  *
- * <p>See {@link PooledQldbDriver} for an example of session lifecycle management, allowing the re-use of sessions when possible.
- * There should only be one thread interacting with a session at any given time.</p>
+ * <p>See {@link PooledQldbDriver} for an example of session lifecycle management, allowing the re-use of sessions when
+ * possible. There should only be one thread interacting with a session at any given time.</p>
  *
- * <p>There are three methods of execution, ranging from simple to complex; the first two are recommended for inbuilt error handling:
+ * <p>There are three methods of execution, ranging from simple to complex; the first two are recommended for inbuilt
+ * error handling:
  * <ul>
  * <li>{@link #execute(String)} and {@link #execute(String, List)} allow for a single statement to be executed within a
- *    transaction where the transaction is implicitly created and committed, and any recoverable errors are transparently
- *    handled.
+ *    transaction where the transaction is implicitly created and committed, and any recoverable errors are
+ *    transparently handled.
  * <li>{@link #execute(Executor, RetryIndicator)} and {@link #execute(ExecutorNoReturn, RetryIndicator)} allow for
  *    more complex execution sequences where more than one execution can occur, as well as other method calls. The
  *    transaction is implicitly created and committed, and any recoverable errors are transparently handled.</li>
- *    {@link #execute(Executor)} and {@link #execute(ExecutorNoReturn)} are also available, providing the same functionality
- *    as the former two functions, but without a lambda function to be invoked upon a retryable error.</li>
+ *    {@link #execute(Executor)} and {@link #execute(ExecutorNoReturn)} are also available, providing the same
+ *    functionality as the former two functions, but without a lambda function to be invoked upon a retryable
+ *    error.</li>
  * <li>{@link #startTransaction()} allows for full control over when the transaction is committed and leaves the
- *    responsibility of OCC conflict handling up to the user. Transactions methods cannot be automatically retried, as the state
- *    of the transaction is ambiguous in the case of an unexpected error.</li>
+ *    responsibility of OCC conflict handling up to the user. Transactions methods cannot be automatically retried, as
+ *    the state of the transaction is ambiguous in the case of an unexpected error.</li>
  * </ul>
  * </p>
  */
@@ -64,8 +65,8 @@ public interface QldbSession extends AutoCloseable {
      *              The PartiQL statement to be executed against QLDB.
      *
      * @return The result of executing the statement.
-     * @throws IllegalStateException if this QldbSession has been closed already, or if the transaction's commit digest does not
-     *                               match the response from QLDB.
+     * @throws IllegalStateException if this QldbSession has been closed already, or if the transaction's commit digest
+     *                               does not match the response from QLDB.
      * @throws OccConflictException if the number of retries has exceeded the limit and an OCC conflict occurs.
      * @throws com.amazonaws.AmazonClientException if there is an error communicating with QLDB.
      */
@@ -80,8 +81,8 @@ public interface QldbSession extends AutoCloseable {
      *              The parameters to be used with the PartiQL statement, for each ? placeholder in the statement.
      *
      * @return The result of executing the statement.
-     * @throws IllegalStateException if this QldbSession has been closed already, or if the transaction's commit digest does not
-     *                               match the response from QLDB.
+     * @throws IllegalStateException if this QldbSession has been closed already, or if the transaction's commit digest
+     *                               does not match the response from QLDB.
      * @throws OccConflictException if the number of retries has exceeded the limit and an OCC conflict occurs.
      * @throws com.amazonaws.AmazonClientException if there is an error communicating with QLDB.
      */
@@ -95,8 +96,8 @@ public interface QldbSession extends AutoCloseable {
      *              This cannot have any side effects as it may be invoked multiple times.
      *
      * @throws AbortException if the Executor lambda calls {@link TransactionExecutor#abort()}.
-     * @throws IllegalStateException if this QldbSession has been closed already, or if the transaction's commit digest does not
-     *                               match the response from QLDB.
+     * @throws IllegalStateException if this QldbSession has been closed already, or if the transaction's commit digest
+     *                               does not match the response from QLDB.
      * @throws OccConflictException if the number of retries has exceeded the limit and an OCC conflict occurs.
      * @throws com.amazonaws.AmazonClientException if there is an error communicating with QLDB.
      */
@@ -109,12 +110,12 @@ public interface QldbSession extends AutoCloseable {
      *              A lambda with no return value representing the block of code to be executed within the transaction.
      *              This cannot have any side effects as it may be invoked multiple times.
      * @param retryIndicator
-     *              A lambda that which is invoked when the Executor lambda is about to be retried due to a retryable error.
-     *              Can be null if not applicable.
+     *              A lambda that which is invoked when the Executor lambda is about to be retried due to a retriable
+     *              error. Can be null if not applicable.
      *
      * @throws AbortException if the Executor lambda calls {@link TransactionExecutor#abort()}.
-     * @throws IllegalStateException if this QldbSession has been closed already, or if the transaction's commit digest does not
-     *                               match the response from QLDB.
+     * @throws IllegalStateException if this QldbSession has been closed already, or if the transaction's commit digest
+     *                               does not match the response from QLDB.
      * @throws OccConflictException if the number of retries has exceeded the limit and an OCC conflict occurs.
      * @throws com.amazonaws.AmazonClientException if there is an error communicating with QLDB.
      */
@@ -128,13 +129,14 @@ public interface QldbSession extends AutoCloseable {
      *              side effects as it may be invoked multiple times, and the result cannot be trusted until the
      *              transaction is committed.
      *
-     * @return The return value of executing the executor. Note that if you directly return a {@link Result}, this will be
-     *         automatically buffered in memory before the implicit commit to allow reading, as the commit will close
-     *         any open results. Any other {@link Result} instances created within the executor block will be invalidated,
-     *         including if the return value is an object which nests said {@link Result} instances within it.
+     * @return The return value of executing the executor. Note that if you directly return a {@link Result}, this will
+     *         be automatically buffered in memory before the implicit commit to allow reading, as the commit will close
+     *         any open results. Any other {@link Result} instances created within the executor block will be
+     *         invalidated, including if the return value is an object which nests said {@link Result} instances within
+     *         it.
      * @throws AbortException if the Executor lambda calls {@link TransactionExecutor#abort()}.
-     * @throws IllegalStateException if this QldbSession has been closed already, or if the transaction's commit digest does not
-     *                               match the response from QLDB.
+     * @throws IllegalStateException if this QldbSession has been closed already, or if the transaction's commit digest
+     *                               does not match the response from QLDB.
      * @throws OccConflictException if the number of retries has exceeded the limit and an OCC conflict occurs.
      * @throws com.amazonaws.AmazonClientException if there is an error communicating with QLDB.
      */
@@ -148,31 +150,21 @@ public interface QldbSession extends AutoCloseable {
      *              side effects as it may be invoked multiple times, and the result cannot be trusted until the
      *              transaction is committed.
      * @param retryIndicator
-     *              A lambda that which is invoked when the Executor lambda is about to be retried due to a retryable error.
-     *              Can be null if not applicable.
+     *              A lambda that which is invoked when the Executor lambda is about to be retried due to a retriable
+     *              error. Can be null if not applicable.
      *
-     * @return The return value of executing the executor. Note that if you directly return a {@link Result}, this will be
-     *         automatically buffered in memory before the implicit commit to allow reading, as the commit will close
-     *         any open results. Any other {@link Result} instances created within the executor block will be invalidated,
-     *         including if the return value is an object which nests said {@link Result} instances within it.
+     * @return The return value of executing the executor. Note that if you directly return a {@link Result}, this will
+     *         be automatically buffered in memory before the implicit commit to allow reading, as the commit will close
+     *         any open results. Any other {@link Result} instances created within the executor block will be
+     *         invalidated, including if the return value is an object which nests said {@link Result} instances within
+     *         it.
      * @throws AbortException if the Executor lambda calls {@link TransactionExecutor#abort()}.
-     * @throws IllegalStateException if this QldbSession has been closed already, or if the transaction's commit digest does not
-     *                               match the response from QLDB.
+     * @throws IllegalStateException if this QldbSession has been closed already, or if the transaction's commit digest
+     *                               does not match the response from QLDB.
      * @throws OccConflictException if the number of retries has exceeded the limit and an OCC conflict occurs.
      * @throws com.amazonaws.AmazonClientException if there is an error communicating with QLDB.
      */
     <T extends Object> T execute(Executor<T> executor, RetryIndicator retryIndicator);
-
-    /**
-     * Retrieve the table names that are available within the ledger.
-     *
-     * @return The Iterable over the table names in the ledger.
-     * @throws IllegalStateException if this QldbSessionImpl has been closed already, or if the transaction's commit digest does not
-     *                               match the response from QLDB.
-     * @throws OccConflictException if the number of retries has exceeded the limit and an OCC conflict occurs.
-     * @throws com.amazonaws.AmazonClientException if there is an error communicating with QLDB.
-     */
-    Iterable<String> getTableNames();
 
     /**
      * Retrieve the name of the ledger for this session.
@@ -187,6 +179,17 @@ public interface QldbSession extends AutoCloseable {
      * @return The session token for this session.
      */
     String getSessionToken();
+
+    /**
+     * Retrieve the table names that are available within the ledger.
+     *
+     * @return The Iterable over the table names in the ledger.
+     * @throws IllegalStateException if this QldbSessionImpl has been closed already, or if the transaction's commit
+     *                               digest does not match the response from QLDB.
+     * @throws OccConflictException if the number of retries has exceeded the limit and an OCC conflict occurs.
+     * @throws com.amazonaws.AmazonClientException if there is an error communicating with QLDB.
+     */
+    Iterable<String> getTableNames();
 
     /**
      * Create a transaction object which allows for granular control over when a transaction is aborted or committed.

--- a/src/main/java/software/amazon/qldb/QldbSessionImpl.java
+++ b/src/main/java/software/amazon/qldb/QldbSessionImpl.java
@@ -1,21 +1,16 @@
 /*
- * Copyright 2014-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at
  *
- * http://aws.amazon.com/apache2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
  * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
  * and limitations under the License.
  */
 package software.amazon.qldb;
-
-import java.net.SocketTimeoutException;
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.ExecutorService;
 
 import com.amazon.ion.IonSystem;
 import com.amazon.ion.IonValue;
@@ -24,6 +19,7 @@ import com.amazonaws.annotation.NotThreadSafe;
 import com.amazonaws.services.qldbsession.model.AmazonQLDBSessionException;
 import com.amazonaws.services.qldbsession.model.InvalidSessionException;
 import com.amazonaws.services.qldbsession.model.OccConflictException;
+import com.amazonaws.services.qldbsession.model.StartTransactionResult;
 import com.amazonaws.util.ValidationUtils;
 import org.apache.http.HttpStatus;
 import org.apache.http.NoHttpResponseException;
@@ -31,25 +27,31 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.qldb.exceptions.AbortException;
 
+import java.net.SocketTimeoutException;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+
 /**
  * Represents a session to a specific ledger within QLDB, allowing for execution of PartiQL statements and
  * retrieval of the associated results, along with control over transactions for bundling multiple executions.
  *
- * The execute methods provided will automatically retry themselves in the case that an unexpected recoverable error occurs,
- * including OCC conflicts, by starting a brand new transaction and re-executing the statement query within the new transaction.
+ * The execute methods provided will automatically retry themselves in the case that an unexpected recoverable error
+ * occurs, including OCC conflicts, by starting a brand new transaction and re-executing the statement within the new
+ * transaction.
  *
  * There are three methods of execution, ranging from simple to complex:
  *  - {@link #execute(String)} and {@link #execute(String, List)} allow for a single statement to be executed within a
- *    transaction where the transaction is implicitly created and committed, and any recoverable errors are transparently
- *    handled.
+ *    transaction where the transaction is implicitly created and committed, and any recoverable errors are
+ *    transparently handled.
  *  - {@link #execute(Executor, RetryIndicator)} and {@link #execute(ExecutorNoReturn, RetryIndicator)} allow for
  *    more complex execution sequences where more than one execution can occur, as well as other method calls. The
  *    transaction is implicitly created and committed, and any recoverable errors are transparently handled.
- *    {@link #execute(Executor)} and {@link #execute(ExecutorNoReturn)} are also available, providing the same functionality
- *    as the former two functions, but without a lambda function to be invoked upon a retryable exception.
+ *    {@link #execute(Executor)} and {@link #execute(ExecutorNoReturn)} are also available, providing the same
+ *    functionality as the former two functions, but without a lambda function to be invoked upon a retriable exception.
  *  - {@link #startTransaction()} allows for full control over when the transaction is committed and leaves the
- *    responsibility of OCC conflict handling up to the user. Transactions methods cannot be automatically retried, as the state
- *    of the transaction is ambiguous in the case of an unexpected error.
+ *    responsibility of OCC conflict handling up to the user. Transactions' methods cannot be automatically retried, as
+ *    the state of the transaction is ambiguous in the case of an unexpected error.
  */
 @NotThreadSafe
 class QldbSessionImpl extends BaseQldbSession implements QldbSession {
@@ -64,6 +66,9 @@ class QldbSessionImpl extends BaseQldbSession implements QldbSession {
         this.executorService = executorService;
     }
 
+    /**
+     * Close this session. No-op if already closed.
+     */
     @Override
     public void close() {
         if (!isClosed.getAndSet(true)) {
@@ -74,18 +79,24 @@ class QldbSessionImpl extends BaseQldbSession implements QldbSession {
     /**
      * Execute the statement against QLDB and retrieve the result.
      *
-     * The execution occurs within a transaction which is implicitly committed, and any recoverable errors, including OCC
-     * conflicts, are handled by starting a new transaction and re-executing the statement up to the retry limit amount of times.
+     * The execution occurs within a transaction which is implicitly committed, and any recoverable errors, including
+     * OCC conflicts, are handled by starting a new transaction and re-executing the statement up to the retry limit
+     * amount of times.
      *
-     * As this function automatically retries on recoverable errors, if the query statement is not idempotent or conditional on
-     * a check within the query itself, this may lead to unexpected results.
+     * As this function automatically retries on recoverable errors, if the statement is not idempotent or conditional
+     * on a check within the statement itself, this may lead to unexpected results.
+     *
+     * If an {@link InvalidSessionException} is caught, it is considered a retriable exception by starting a new
+     * {@link Session} to use for communicating with QLDB. Thus, as a side effect, this QldbSessionImpl can become valid
+     * again despite a previous InvalidSessionException originating from other function calls on this object, or any
+     * child {@link Transaction} and {@link Result} objects, when this function is invoked.
      *
      * @param statement
      *              The PartiQL statement to be executed against QLDB.
      *
      * @return The result of executing the statement.
-     * @throws IllegalStateException if this QldbSessionImpl has been closed already, or if the transaction's commit digest does not
-     *                               match the response from QLDB.
+     * @throws IllegalStateException if this QldbSessionImpl has been closed already, or if the transaction's commit
+     *                               digest does not match the response from QLDB.
      * @throws OccConflictException if the number of retries has exceeded the limit and an OCC conflict occurs.
      */
     @Override
@@ -96,11 +107,17 @@ class QldbSessionImpl extends BaseQldbSession implements QldbSession {
     /**
      * Execute the statement using the specified parameters against QLDB and retrieve the result.
      *
-     * The execution occurs within a transaction which is implicitly committed, and any recoverable errors, including OCC
-     * conflicts, are handled by starting a new transaction and re-executing the statement up to the retry limit amount of times.
+     * The execution occurs within a transaction which is implicitly committed, and any recoverable errors, including
+     * OCC conflicts, are handled by starting a new transaction and re-executing the statement up to the retry limit
+     * amount of times.
      *
-     * As this function automatically retries on recoverable errors, if the query statement is not idempotent or conditional on
-     * a check within the query itself, this may lead to unexpected results.
+     * As this function automatically retries on recoverable errors, if the statement is not idempotent or conditional
+     * on a check within the statement itself, this may lead to unexpected results.
+     *
+     * If an {@link InvalidSessionException} is caught, it is considered a retriable exception by starting a new
+     * {@link Session} to use for communicating with QLDB. Thus, as a side effect, this QldbSessionImpl can become valid
+     * again despite a previous InvalidSessionException originating from other function calls on this object, or any
+     * child {@link Transaction} and {@link Result} objects, when this function is invoked.
      *
      * @param statement
      *              The PartiQL statement to be executed against QLDB.
@@ -108,8 +125,8 @@ class QldbSessionImpl extends BaseQldbSession implements QldbSession {
      *              The parameters to be used with the PartiQL statement, for each ? placeholder in the statement.
      *
      * @return The result of executing the statement.
-     * @throws IllegalStateException if this QldbSessionImpl has been closed already, or if the transaction's commit digest does not
-     *                               match the response from QLDB.
+     * @throws IllegalStateException if this QldbSessionImpl has been closed already, or if the transaction's commit
+     *                               digest does not match the response from QLDB.
      * @throws OccConflictException if the number of retries has exceeded the limit and an OCC conflict occurs.
      */
     @Override
@@ -123,19 +140,25 @@ class QldbSessionImpl extends BaseQldbSession implements QldbSession {
     /**
      * Execute the Executor lambda against QLDB within a transaction where no result is expected.
      *
-     * The execution occurs within a transaction which is implicitly committed, and any recoverable errors, including OCC
-     * conflicts, are handled by starting a new transaction and re-executing the statement up to the retry limit amount of times.
+     * The execution occurs within a transaction which is implicitly committed, and any recoverable errors, including
+     * OCC conflicts, are handled by starting a new transaction and re-executing the statement up to the retry limit
+     * amount of times.
      *
-     * As this function automatically retries on recoverable errors, if the query statements are not idempotent or conditional on
-     * a check within the executor, this may lead to unexpected results.
+     * As this function automatically retries on recoverable errors, if the statements are not idempotent or conditional
+     * on a check within the executor, this may lead to unexpected results.
+     *
+     * If an {@link InvalidSessionException} is caught, it is considered a retriable exception by starting a new
+     * {@link Session} to use for communicating with QLDB. Thus, as a side effect, this QldbSessionImpl can become valid
+     * again despite a previous InvalidSessionException originating from other function calls on this object, or any
+     * child {@link Transaction} and {@link Result} objects, when this function is invoked.
      *
      * @param executor
      *              A lambda with no return value representing the block of code to be executed within the transaction.
      *              This cannot have any side effects as it may be invoked multiple times.
      *
      * @throws AbortException if the Executor lambda calls {@link TransactionExecutor#abort()}.
-     * @throws IllegalStateException if this QldbSessionImpl has been closed already, or if the transaction's commit digest does not
-     *                               match the response from QLDB.
+     * @throws IllegalStateException if this QldbSessionImpl has been closed already, or if the transaction's commit
+     *                               digest does not match the response from QLDB.
      * @throws OccConflictException if the number of retries has exceeded the limit and an OCC conflict occurs.
      */
     @Override
@@ -146,22 +169,28 @@ class QldbSessionImpl extends BaseQldbSession implements QldbSession {
     /**
      * Execute the Executor lambda against QLDB within a transaction where no result is expected.
      *
-     * The execution occurs within a transaction which is implicitly committed, and any recoverable errors, including OCC
-     * conflicts, are handled by starting a new transaction and re-executing the statement up to the retry limit amount of times.
+     * The execution occurs within a transaction which is implicitly committed, and any recoverable errors, including
+     * OCC conflicts, are handled by starting a new transaction and re-executing the statement up to the retry limit
+     * amount of times.
      *
-     * As this function automatically retries on recoverable errors, if the query statements are not idempotent or conditional on
-     * a check within the executor, this may lead to unexpected results.
+     * As this function automatically retries on recoverable errors, if the statements are not idempotent or conditional
+     * on a check within the executor, this may lead to unexpected results.
+     *
+     * If an {@link InvalidSessionException} is caught, it is considered a retriable exception by starting a new
+     * {@link Session} to use for communicating with QLDB. Thus, as a side effect, this QldbSessionImpl can become valid
+     * again despite a previous InvalidSessionException originating from other function calls on this object, or any
+     * child {@link Transaction} and {@link Result} objects, when this function is invoked.
      *
      * @param executor
      *              A lambda with no return value representing the block of code to be executed within the transaction.
      *              This cannot have any side effects as it may be invoked multiple times.
      * @param retryIndicator
-     *              A lambda that which is invoked when the Executor lambda is about to be retried due to a retryable error.
-     *              Can be null if not applicable.
+     *              A lambda that which is invoked when the Executor lambda is about to be retried due to a retriable
+     *              error. Can be null if not applicable.
      *
      * @throws AbortException if the Executor lambda calls {@link TransactionExecutor#abort()}.
-     * @throws IllegalStateException if this QldbSessionImpl has been closed already, or if the transaction's commit digest does not
-     *                               match the response from QLDB.
+     * @throws IllegalStateException if this QldbSessionImpl has been closed already, or if the transaction's commit
+     *                               digest does not match the response from QLDB.
      * @throws OccConflictException if the number of retries has exceeded the limit and an OCC conflict occurs.
      */
     @Override
@@ -177,25 +206,31 @@ class QldbSessionImpl extends BaseQldbSession implements QldbSession {
     /**
      * Execute the Executor lambda against QLDB and retrieve the result within a transaction.
      *
-     * The execution occurs within a transaction which is implicitly committed, and any recoverable errors, including OCC
-     * conflicts, are handled by starting a new transaction and re-executing the statement up to the retry limit amount of times.
-     * The Result of the Executor lambda cannot be deemed accurate until this method completes.
+     * The execution occurs within a transaction which is implicitly committed, and any recoverable errors, including
+     * OCC conflicts, are handled by starting a new transaction and re-executing the statement up to the retry limit
+     * amount of times. The Result of the Executor lambda cannot be deemed accurate until this method completes.
      *
-     * As this function automatically retries on recoverable errors, if the query statements are not idempotent or conditional on
-     * a check within the executor, this may lead to unexpected results.
+     * As this function automatically retries on recoverable errors, if the statements are not idempotent or conditional
+     * on a check within the executor, this may lead to unexpected results.
+     *
+     * If an {@link InvalidSessionException} is caught, it is considered a retriable exception by starting a new
+     * {@link Session} to use for communicating with QLDB. Thus, as a side effect, this QldbSessionImpl can become valid
+     * again despite a previous InvalidSessionException originating from other function calls on this object, or any
+     * child {@link Transaction} and {@link Result} objects, when this function is invoked.
      *
      * @param executor
      *              A lambda representing the block of code to be executed within the transaction. This cannot have any
      *              side effects as it may be invoked multiple times, and the result cannot be trusted until the
      *              transaction is committed.
      *
-     * @return The return value of executing the executor. Note that if you directly return a {@link Result}, this will be
-     *         automatically buffered in memory before the implicit commit to allow reading, as the commit will close
-     *         any open results. Any other {@link Result} instances created within the executor block will be invalidated,
-     *         including if the return value is an object which nests said {@link Result} instances within it.
+     * @return The return value of executing the executor. Note that if you directly return a {@link Result}, this will
+     *         be automatically buffered in memory before the implicit commit to allow reading, as the commit will close
+     *         any open results. Any other {@link Result} instances created within the executor block will be
+     *         invalidated, including if the return value is an object which nests said {@link Result} instances within
+     *         it.
      * @throws AbortException if the Executor lambda calls {@link TransactionExecutor#abort()}.
-     * @throws IllegalStateException if this QldbSessionImpl has been closed already, or if the transaction's commit digest does not
-     *                               match the response from QLDB.
+     * @throws IllegalStateException if this QldbSessionImpl has been closed already, or if the transaction's commit
+     *                               digest does not match the response from QLDB.
      * @throws OccConflictException if the number of retries has exceeded the limit and an OCC conflict occurs.
      */
     @Override
@@ -206,28 +241,34 @@ class QldbSessionImpl extends BaseQldbSession implements QldbSession {
     /**
      * Execute the Executor lambda against QLDB and retrieve the result within a transaction.
      *
-     * The execution occurs within a transaction which is implicitly committed, and any recoverable errors, including OCC
-     * conflicts, are handled by starting a new transaction and re-executing the statement up to the retry limit amount of times.
-     * The Result of the Executor lambda cannot be deemed accurate until this method completes.
+     * The execution occurs within a transaction which is implicitly committed, and any recoverable errors, including
+     * OCC conflicts, are handled by starting a new transaction and re-executing the statement up to the retry limit
+     * amount of times. The Result of the Executor lambda cannot be deemed accurate until this method completes.
      *
-     * As this function automatically retries on recoverable errors, if the query statements are not idempotent or conditional on
-     * a check within the executor, this may lead to unexpected results.
+     * As this function automatically retries on recoverable errors, if the statements are not idempotent or conditional
+     * on a check within the executor, this may lead to unexpected results.
+     *
+     * If an {@link InvalidSessionException} is caught, it is considered a retriable exception by starting a new
+     * {@link Session} to use for communicating with QLDB. Thus, as a side effect, this QldbSessionImpl can become valid
+     * again despite a previous InvalidSessionException originating from other function calls on this object, or any
+     * child {@link Transaction} and {@link Result} objects, when this function is invoked.
      *
      * @param executor
      *              A lambda representing the block of code to be executed within the transaction. This cannot have any
      *              side effects as it may be invoked multiple times, and the result cannot be trusted until the
      *              transaction is committed.
      * @param retryIndicator
-     *              A lambda that which is invoked when the Executor lambda is about to be retried due to a retryable error.
-     *              Can be null if not applicable.
+     *              A lambda that which is invoked when the Executor lambda is about to be retried due to a retriable
+     *              error. Can be null if not applicable.
      *
-     * @return The return value of executing the executor. Note that if you directly return a {@link Result}, this will be
-     *         automatically buffered in memory before the implicit commit to allow reading, as the commit will close
-     *         any open results. Any other {@link Result} instances created within the executor block will be invalidated,
-     *         including if the return value is an object which nests said {@link Result} instances within it.
+     * @return The return value of executing the executor. Note that if you directly return a {@link Result}, this will
+     *         be automatically buffered in memory before the implicit commit to allow reading, as the commit will close
+     *         any open results. Any other {@link Result} instances created within the executor block will be
+     *         invalidated, including if the return value is an object which nests said {@link Result} instances within
+     *         it.
      * @throws AbortException if the Executor lambda calls {@link TransactionExecutor#abort()}.
-     * @throws IllegalStateException if this QldbSessionImpl has been closed already, or if the transaction's commit digest does not
-     *                               match the response from QLDB.
+     * @throws IllegalStateException if this QldbSessionImpl has been closed already, or if the transaction's commit
+     *                               digest does not match the response from QLDB.
      * @throws OccConflictException if the number of retries has exceeded the limit and an OCC conflict occurs.
      */
     @Override
@@ -236,55 +277,58 @@ class QldbSessionImpl extends BaseQldbSession implements QldbSession {
         ValidationUtils.assertNotNull(executor, "executor");
 
         for (int executionAttempt = 0; true;) {
-                Transaction transaction = null;
-                try {
-                    transaction = startTransaction();
-                    T returnedValue = executor.execute(new TransactionExecutor(transaction));
-                    if (returnedValue instanceof StreamResult) {
-                        // If someone accidentally returned a StreamResult object which would become invalidated by the
-                        // commit, automatically buffer it to allow them to use the result anyway.
-                        returnedValue = (T) new BufferedResult((Result) returnedValue);
-                    }
-                    transaction.commit();
-                    return returnedValue;
-                } catch (InvalidSessionException ise) {
-                    isClosed.set(true);
+            Transaction transaction = null;
+            try {
+                transaction = startTransaction();
+                T returnedValue = executor.execute(new TransactionExecutor(transaction));
+                if (returnedValue instanceof StreamResult) {
+                    // If someone accidentally returned a StreamResult object which would become invalidated by the
+                    // commit, automatically buffer it to allow them to use the result anyway.
+                    returnedValue = (T) new BufferedResult((Result) returnedValue);
+                }
+                transaction.commit();
+                return returnedValue;
+            } catch (AbortException e) {
+                noThrowAbort(transaction);
+                throw e;
+            } catch (InvalidSessionException ise) {
+                if (executionAttempt >= retryLimit) {
                     throw ise;
-                } catch (AbortException e) {
-                    noThrowAbort(transaction);
-                    throw e;
-                } catch (OccConflictException oce) {
-                    logger.info("OCC conflict occurred: " + oce.getMessage());
-                    if (executionAttempt >= retryLimit) {
-                        throw oce;
-                    }
-                } catch (AmazonQLDBSessionException se) {
-                    noThrowAbort(transaction);
-
-                    // If the error is an internal server error, or service unavailable, retry the transaction. QLDB
-                    // considers these exceptions to be non-fatal and retryable. Otherwise, bubble the exception up to
-                    // the user.
-                    if ((executionAttempt >= retryLimit) || ((se.getStatusCode() != HttpStatus.SC_INTERNAL_SERVER_ERROR) &&
-                            (se.getStatusCode() != HttpStatus.SC_SERVICE_UNAVAILABLE))) {
-                        throw se;
-                    }
-                } catch (AmazonClientException ace) {
-                    noThrowAbort(transaction);
-
-                    // Retry if it's a timeout or a no response error.
-                    if ((executionAttempt >= retryLimit) || (!(ace.getCause() instanceof NoHttpResponseException ||
-                            ace.getCause() instanceof SocketTimeoutException))) {
-                        throw ace;
-                    }
                 }
-
-                ++executionAttempt;
-                if (null != retryIndicator) {
-                    retryIndicator.onRetry(executionAttempt);
+                logger.info("Creating a new session to QLDB; previous session is no longer valid.", ise);
+                session = Session.startSession(session.getLedgerName(), session.getClient());
+            } catch (OccConflictException oce) {
+                logger.info("OCC conflict occurred.", oce);
+                if (executionAttempt >= retryLimit) {
+                    throw oce;
                 }
+            } catch (AmazonQLDBSessionException se) {
+                noThrowAbort(transaction);
 
-                // There was a non-fatal error that occurred, so sleep for a bit before retry.
-                retrySleep(executionAttempt);
+                // If the error is an internal server error, or service unavailable, retry the transaction. QLDB
+                // considers these exceptions to be non-fatal and retriable. Otherwise, bubble the exception up to
+                // the user.
+                if ((executionAttempt >= retryLimit) || ((se.getStatusCode() != HttpStatus.SC_INTERNAL_SERVER_ERROR) &&
+                        (se.getStatusCode() != HttpStatus.SC_SERVICE_UNAVAILABLE))) {
+                    throw se;
+                }
+            } catch (AmazonClientException ace) {
+                noThrowAbort(transaction);
+
+                // Retry if it's a timeout or a no response error.
+                if ((executionAttempt >= retryLimit) || (!(ace.getCause() instanceof NoHttpResponseException ||
+                        ace.getCause() instanceof SocketTimeoutException))) {
+                    throw ace;
+                }
+            }
+
+            ++executionAttempt;
+            if (null != retryIndicator) {
+                retryIndicator.onRetry(executionAttempt);
+            }
+
+            // There was a non-fatal error that occurred, so sleep for a bit before retry.
+            retrySleep(executionAttempt);
         }
     }
 
@@ -298,12 +342,38 @@ class QldbSessionImpl extends BaseQldbSession implements QldbSession {
     public Transaction startTransaction() {
         throwIfClosed();
 
-        try {
-            return new TransactionImpl(this, session.sendStartTransaction(), readAhead, ionSystem, executorService);
-        } catch (InvalidSessionException ise) {
-            isClosed.set(true);
-            throw ise;
+        final StartTransactionResult startTransaction = session.sendStartTransaction();
+        return new TransactionImpl(session, startTransaction.getTransactionId(), readAhead, ionSystem, executorService);
+    }
+
+    /**
+     * Determine if the session is alive by sending an abort message. Will close the session if the abort is
+     * unsuccessful.
+     *
+     * This should only be used when the session is known to not be in use, otherwise the state will be abandoned.
+     *
+     * @return {@code true} if the session was aborted successfully; {@code false} if the session is closed.
+     */
+    boolean abortOrClose() {
+        if (isClosed.get()) {
+            return false;
         }
+        try {
+            session.sendAbort();
+            return true;
+        } catch (AmazonClientException e) {
+            isClosed.set(true);
+            return false;
+        }
+    }
+
+    /**
+     * Retrieve the session ID of this session.
+     *
+     * @return The session ID for this session.
+     */
+    String getSessionId() {
+        return this.session.getId();
     }
 
     /**
@@ -313,14 +383,12 @@ class QldbSessionImpl extends BaseQldbSession implements QldbSession {
      *                  The transaction to abort.
      */
     private void noThrowAbort(Transaction transaction) {
-        if (null == transaction) {
-            return;
-        }
         try {
-            transaction.abort();
-        } catch (InvalidSessionException ise) {
-            isClosed.set(true);
-            throw ise;
+            if (null == transaction) {
+                session.sendAbort();
+            } else {
+                transaction.abort();
+            }
         } catch (AmazonClientException ace) {
             logger.warn("Ignored error aborting transaction during execution.", ace);
         }

--- a/src/main/java/software/amazon/qldb/Result.java
+++ b/src/main/java/software/amazon/qldb/Result.java
@@ -1,10 +1,10 @@
 /*
- * Copyright 2014-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at
  *
- * http://aws.amazon.com/apache2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
  * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions

--- a/src/main/java/software/amazon/qldb/ResultHolder.java
+++ b/src/main/java/software/amazon/qldb/ResultHolder.java
@@ -1,10 +1,10 @@
 /*
- * Copyright 2014-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at
  *
- * http://aws.amazon.com/apache2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
  * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
@@ -64,21 +64,21 @@ class ResultHolder<T> {
     }
 
     /**
-     * Retrieve the result associated with this holder.
-     *
-     * @return The result associated with this holder.
-     */
-    public Page getResult() {
-        return result;
-    }
-
-    /**
      * Retrieve the associated value from this holder.
      *
      * @return The associated value from this holder.
      */
     public T getAssociatedValue() {
         return associatedValue;
+    }
+
+    /**
+     * Retrieve the result associated with this holder.
+     *
+     * @return The result associated with this holder.
+     */
+    public Page getResult() {
+        return result;
     }
 
     @Override

--- a/src/main/java/software/amazon/qldb/RetryIndicator.java
+++ b/src/main/java/software/amazon/qldb/RetryIndicator.java
@@ -1,10 +1,10 @@
 /*
- * Copyright 2014-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at
  *
- * http://aws.amazon.com/apache2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
  * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
@@ -13,9 +13,9 @@
 package software.amazon.qldb;
 
 /**
- * Represents a function that is invoked when a recoverable error, including OCC conflicts, occurs and the retry limit has not yet
- * been exceeded, indicating that a new transaction is about to be created and the Executor lambda re-invoked. The retry attempt
- * is passed in as a parameter.
+ * Represents a function that is invoked when a recoverable error, including OCC conflicts, occurs and the retry limit
+ * has not yet been exceeded, indicating that a new transaction is about to be created and the Executor lambda
+ * re-invoked. The retry attempt is passed in as a parameter.
  */
 @FunctionalInterface
 public interface RetryIndicator {

--- a/src/main/java/software/amazon/qldb/StreamResult.java
+++ b/src/main/java/software/amazon/qldb/StreamResult.java
@@ -1,10 +1,10 @@
 /*
- * Copyright 2014-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at
  *
- * http://aws.amazon.com/apache2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
  * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
@@ -12,19 +12,17 @@
  */
 package software.amazon.qldb;
 
-import java.util.Iterator;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.atomic.AtomicBoolean;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.amazon.ion.IonSystem;
 import com.amazon.ion.IonValue;
 import com.amazonaws.annotation.NotThreadSafe;
 import com.amazonaws.services.qldbsession.model.Page;
-
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import software.amazon.qldb.exceptions.Errors;
+
+import java.util.Iterator;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Result implementation which streams data from QLDB, discarding chunks as they are read.
@@ -123,8 +121,8 @@ class StreamResult extends BaseResult implements Result {
          * Get boolean indicating if there is a next value in the iterator.
          *
          * @return Boolean indicating whether or not there is a next value.
-         * @throws com.amazonaws.AmazonClientException if there is an error communicating with QLDB, when trying to get the next
-         *                                             page of results.
+         * @throws com.amazonaws.AmazonClientException if there is an error communicating with QLDB, when trying to get
+         *                                             the next page of results.
          */
         @Override
         public boolean hasNext() {
@@ -134,9 +132,9 @@ class StreamResult extends BaseResult implements Result {
         /**
          * Get the next value in the iterator.
          *
-         * @return The next IonValue resulting from the execution query.
-         * @throws com.amazonaws.AmazonClientException if there is an error communicating with QLDB, when trying to get the next
-         *                                             page of results.
+         * @return The next IonValue resulting from the execution statement.
+         * @throws com.amazonaws.AmazonClientException if there is an error communicating with QLDB, when trying to get
+         *                                             the next page of results.
          */
         @Override
         public IonValue next() {

--- a/src/main/java/software/amazon/qldb/TableNameIterable.java
+++ b/src/main/java/software/amazon/qldb/TableNameIterable.java
@@ -1,10 +1,10 @@
 /*
- * Copyright 2014-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at
  *
- * http://aws.amazon.com/apache2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
  * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
@@ -12,18 +12,16 @@
  */
 package software.amazon.qldb;
 
-import java.util.Iterator;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.amazon.ion.IonReader;
 import com.amazon.ion.IonType;
 import com.amazon.ion.IonValue;
 import com.amazon.ion.system.IonReaderBuilder;
 import com.amazonaws.annotation.NotThreadSafe;
-
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import software.amazon.qldb.exceptions.Errors;
+
+import java.util.Iterator;
 
 /**
  * Iterable class to create an iterator over a result representing the list of tables within a ledger.

--- a/src/main/java/software/amazon/qldb/Transaction.java
+++ b/src/main/java/software/amazon/qldb/Transaction.java
@@ -1,10 +1,10 @@
 /*
- * Copyright 2014-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at
  *
- * http://aws.amazon.com/apache2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
  * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
@@ -12,29 +12,30 @@
  */
 package software.amazon.qldb;
 
-import java.util.List;
-
 import com.amazon.ion.IonValue;
 import com.amazonaws.annotation.NotThreadSafe;
 import com.amazonaws.services.qldbsession.model.OccConflictException;
+
+import java.util.List;
 
 /**
  * <p>Interface that represents an active transaction with QLDB.</p>
  *
  *
- * <p>Every transaction is tied to the parent {@link QldbSession}, meaning that if the parent session is closed or invalidated, the
- * child transaction is automatically closed and cannot be used. Only one transaction can be active at any given time per parent
- * session, and thus every transaction should call {@link #abort()} or {@link #commit()} when it is no longer needed, or when a
- * new transaction is wanted from the parent session.</p>
+ * <p>Every transaction is tied to the parent {@link QldbSession}, meaning that if the parent session is closed or
+ * invalidated, the child transaction is automatically closed and cannot be used. Only one transaction can be active at
+ * any given time per parent session, and thus every transaction should call {@link #abort()} or {@link #commit()} when
+ * it is no longer needed, or when a new transaction is wanted from the parent session.</p>
  *
- * <p>An {@link com.amazonaws.services.qldbsession.model.InvalidSessionException} indicates that the parent session is dead, and a
- * new transaction cannot be created without a new {@link QldbSession} being created from the parent driver.</p>
+ * <p>An {@link com.amazonaws.services.qldbsession.model.InvalidSessionException} indicates that the parent session is
+ * dead, and a new transaction cannot be created without a new {@link QldbSession} being created from the parent
+ * driver.</p>
  *
- * <p>Any unexpected errors that occur within a transaction should not be retried using the same transaction, as the state of the
- * transaction is now ambiguous.</p>
+ * <p>Any unexpected errors that occur within a transaction should not be retried using the same transaction, as the
+ * state of the transaction is now ambiguous.</p>
  *
- * <p>When an OCC conflict occurs, the transaction is closed and must be handled manually by creating a new transaction and
- * re-executing the desired queries.</p>
+ * <p>When an OCC conflict occurs, the transaction is closed and must be handled manually by creating a new transaction
+ * and re-executing the desired queries.</p>
  *
  * <p>Child Result objects will be closed when the transaction is aborted or committed.</p>
  */
@@ -42,7 +43,6 @@ import com.amazonaws.services.qldbsession.model.OccConflictException;
 public interface Transaction extends AutoCloseable {
     /**
      * Abort the transaction and roll back any changes. Any open Results created by the transaction will be closed.
-     *
      *
      * @throws com.amazonaws.AmazonClientException if there is an error communicating with QLDB.
      */
@@ -56,11 +56,12 @@ public interface Transaction extends AutoCloseable {
     /**
      * <p>Commit the transaction. Any open {@link Result} created by the transaction will be closed.</p>
      *
-     * <p>If QLDB detects that there has been an optimistic concurrency control conflict (failed validation check to ensure
-     * no other committed transaction has modified data that was read) then an OccConflictException will be thrown.</p>
+     * <p>If QLDB detects that there has been an optimistic concurrency control conflict (failed validation check to
+     * ensure no other committed transaction has modified data that was read) then an OccConflictException will be
+     * thrown.</p>
      *
-     * @throws IllegalStateException if the transaction has been committed or aborted already, or if the returned commit digest
-     *                               from QLDB does not match.
+     * @throws IllegalStateException if the transaction has been committed or aborted already, or if the returned commit
+     *                               digest from QLDB does not match.
      * @throws OccConflictException if an OCC conflict has been detected within the transaction.
      * @throws com.amazonaws.AmazonClientException if there is an error communicating with QLDB.
      */

--- a/src/main/java/software/amazon/qldb/TransactionExecutor.java
+++ b/src/main/java/software/amazon/qldb/TransactionExecutor.java
@@ -1,10 +1,10 @@
 /*
- * Copyright 2014-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at
  *
- * http://aws.amazon.com/apache2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
  * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
@@ -12,14 +12,12 @@
  */
 package software.amazon.qldb;
 
-import java.util.List;
-
+import com.amazon.ion.IonValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.amazon.ion.IonValue;
-
 import software.amazon.qldb.exceptions.AbortException;
+
+import java.util.List;
 
 /**
  * Transaction object used within lambda executions to provide a reduced view that allows only the operations that are

--- a/src/main/java/software/amazon/qldb/TransactionImpl.java
+++ b/src/main/java/software/amazon/qldb/TransactionImpl.java
@@ -1,16 +1,27 @@
 /*
- * Copyright 2014-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at
  *
- * http://aws.amazon.com/apache2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
  * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
  * and limitations under the License.
  */
 package software.amazon.qldb;
+
+import com.amazon.ion.IonSystem;
+import com.amazon.ion.IonValue;
+import com.amazonaws.AmazonClientException;
+import com.amazonaws.annotation.NotThreadSafe;
+import com.amazonaws.services.qldbsession.model.ExecuteStatementResult;
+import com.amazonaws.services.qldbsession.model.OccConflictException;
+import com.amazonaws.util.ValidationUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.qldb.exceptions.Errors;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayDeque;
@@ -19,30 +30,16 @@ import java.util.Deque;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 
-import com.amazonaws.AmazonClientException;
-import com.amazonaws.services.qldbsession.model.InvalidSessionException;
-import com.amazonaws.services.qldbsession.model.OccConflictException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.amazon.ion.IonSystem;
-import com.amazon.ion.IonValue;
-import com.amazonaws.annotation.NotThreadSafe;
-import com.amazonaws.services.qldbsession.model.ExecuteStatementResult;
-import com.amazonaws.util.ValidationUtils;
-
-import software.amazon.qldb.exceptions.Errors;
-
 /**
  * Implementation of a QLDB transaction which also tracks child Results for the purposes of managing their lifecycle.
  *
- * Any unexpected errors that occur when calling methods in this class should not be retried, as the state of the transaction is
- * now ambiguous. When an OCC conflict occurs, the transaction is closed.
+ * Any unexpected errors that occur when calling methods in this class should not be retried, as the state of the
+ * transaction is now ambiguous. When an OCC conflict occurs, the transaction is closed.
  *
  * Child Result objects will be closed when the transaction is aborted or committed.
  */
 @NotThreadSafe
-class TransactionImpl extends BaseTransaction implements Transaction  {
+class TransactionImpl extends BaseTransaction implements Transaction {
     private static final Logger logger = LoggerFactory.getLogger(TransactionImpl.class);
 
     private final int readAheadBufferCount;
@@ -52,9 +49,9 @@ class TransactionImpl extends BaseTransaction implements Transaction  {
     // by the operations performed on QLDB.
     private final Deque<Result> results;
 
-    TransactionImpl(QldbSessionImpl qldbSession, String txnId, int readAheadBufferCount, IonSystem ionSystem,
+    TransactionImpl(Session session, String txnId, int readAheadBufferCount, IonSystem ionSystem,
                     ExecutorService executorService) {
-        super(qldbSession, txnId, ionSystem);
+        super(session, txnId, ionSystem);
         Validate.assertIsNotNegative(readAheadBufferCount, "readAheadBufferCount");
         this.readAheadBufferCount = readAheadBufferCount;
         this.executorService = executorService;
@@ -65,44 +62,35 @@ class TransactionImpl extends BaseTransaction implements Transaction  {
     public void abort() {
         if (!isClosed.get()) {
             internalClose();
-            try {
-                session.sendAbort();
-            } catch (InvalidSessionException ise) {
-                qldbSession.softClose();
-                throw ise;
-            }
+            session.sendAbort();
+        }
+    }
+
+    @Override
+    public void close() {
+        try {
+            abort();
+        } catch (AmazonClientException ace) {
+            logger.warn("Ignored error aborting transaction when closing.", ace);
         }
     }
 
     @Override
     public void commit() {
-        if (isClosed.get()) {
-            logger.error(Errors.TXN_CLOSED.get());
-            throw new IllegalStateException(Errors.TXN_CLOSED.get());
-        }
+        throwIfClosed();
 
         try {
             final ByteBuffer hashByteBuffer = ByteBuffer.wrap(getTransactionHash().getQldbHash());
-            final ByteBuffer commitDigest = session.sendCommit(txnId, hashByteBuffer);
+            final ByteBuffer commitDigest = session.sendCommit(txnId, hashByteBuffer).getCommitDigest();
             if (!commitDigest.equals(hashByteBuffer)) {
                 logger.error(Errors.TXN_DIGEST_MISMATCH.get());
                 throw new IllegalStateException(Errors.TXN_DIGEST_MISMATCH.get());
             }
-        } catch (InvalidSessionException ise) {
-            qldbSession.softClose();
-            throw ise;
         } catch (OccConflictException oce) {
             // Avoid sending courtesy abort since we know transaction is dead on OCC conflict.
             throw oce;
         } catch (AmazonClientException ace) {
-            try {
-                session.sendAbort();
-            } catch (InvalidSessionException ise) {
-                qldbSession.softClose();
-                throw ise;
-            } catch (AmazonClientException ace2) {
-                logger.warn("Ignored error aborting transaction after a failed commit.", ace2);
-            }
+            close();
             throw ace;
         } finally {
             internalClose();
@@ -116,36 +104,22 @@ class TransactionImpl extends BaseTransaction implements Transaction  {
 
     @Override
     public Result execute(String statement, List<IonValue> parameters) {
-        if (isClosed.get()) {
-            logger.error(Errors.TXN_CLOSED.get());
-            throw new IllegalStateException(Errors.TXN_CLOSED.get());
-        }
+        throwIfClosed();
         ValidationUtils.assertStringNotEmpty(statement, "statement");
         ValidationUtils.assertNotNull(parameters, "parameters");
 
-        try {
-            setTransactionHash(dot(getTransactionHash(), statement, parameters, ionSystem));
-            final ExecuteStatementResult executeStatementResult = session.sendExecute(statement, parameters, txnId);
-            final StreamResult result = new StreamResult(session, executeStatementResult.getFirstPage(), txnId,
-                    readAheadBufferCount, ionSystem, executorService);
-            results.add(result);
-            return result;
-        } catch (InvalidSessionException ise) {
-            qldbSession.softClose();
-            internalClose();
-            throw ise;
-        }
-    }
-
-    @Override
-    public void close() {
-        abort();
+        setTransactionHash(dot(getTransactionHash(), statement, parameters, ionSystem));
+        final ExecuteStatementResult executeStatementResult = session.sendExecute(statement, parameters, txnId);
+        final StreamResult result = new StreamResult(session, executeStatementResult.getFirstPage(), txnId,
+                readAheadBufferCount, ionSystem, executorService);
+        results.add(result);
+        return result;
     }
 
     /**
-     * Mark the transaction as closed.
+     * Mark the transaction as closed, and stop retrieval threads for any child {@link StreamResult} objects.
      */
-    private void internalClose() {
+    void internalClose() {
         isClosed.set(true);
         while (!results.isEmpty()) {
             // Avoid the use of forEach to guard against potential concurrent modification issues.

--- a/src/main/java/software/amazon/qldb/Validate.java
+++ b/src/main/java/software/amazon/qldb/Validate.java
@@ -1,10 +1,10 @@
 /*
- * Copyright 2014-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at
  *
- * http://aws.amazon.com/apache2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
  * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions

--- a/src/main/java/software/amazon/qldb/exceptions/AbortException.java
+++ b/src/main/java/software/amazon/qldb/exceptions/AbortException.java
@@ -1,10 +1,10 @@
 /*
- * Copyright 2014-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at
  *
- * http://aws.amazon.com/apache2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
  * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
@@ -16,5 +16,4 @@ package software.amazon.qldb.exceptions;
  * Exception type representing the abort of a transaction within a lambda execution block. Signals that the lambda
  * should cease to execute and the current transaction should be aborted.
  */
-public class AbortException extends RuntimeException {
-}
+public class AbortException extends RuntimeException {}

--- a/src/main/java/software/amazon/qldb/exceptions/Errors.java
+++ b/src/main/java/software/amazon/qldb/exceptions/Errors.java
@@ -1,10 +1,10 @@
 /*
- * Copyright 2014-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at
  *
- * http://aws.amazon.com/apache2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
  * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
@@ -18,9 +18,6 @@ import java.util.ResourceBundle;
  * Enum identifying the possible errors within the QLDB session, allowing for retrieval of a localized error message.
  */
 public enum Errors {
-    ASNYC_BUFFERING_FAILED,
-    ASYNC_EXECUTE_INTERRUPTED,
-    ASYNC_EXECUTE_FAILED,
     DRIVER_CLOSED,
     GET_SESSION_INTERRUPTED,
     INCORRECT_TYPE,

--- a/src/main/java/software/amazon/qldb/exceptions/QldbClientException.java
+++ b/src/main/java/software/amazon/qldb/exceptions/QldbClientException.java
@@ -1,10 +1,10 @@
 /*
- * Copyright 2014-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at
  *
- * http://aws.amazon.com/apache2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
  * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
@@ -122,7 +122,8 @@ public class QldbClientException extends AmazonClientException {
     }
 
     /**
-     * Factory method for creating an exception with a specific message including the session token wrapping another exception.
+     * Factory method for creating an exception with a specific message, including the session token, wrapping another
+     * exception.
      *
      * Will automatically log the exception on creation as well.
      *

--- a/src/main/resources/errors.properties
+++ b/src/main/resources/errors.properties
@@ -1,6 +1,3 @@
-ASNYC_BUFFERING_FAILED=Unexpected failure when buffering asynchronous result into memory.
-ASNYC_EXECUTE_INTERRUPTED=Interrupted while asynchronously executing a query.
-ASYNC_EXECUTE_FAILED=Unexpected failure when asynchronously executing a query.
 DRIVER_CLOSED=Operation is invalid as this QldbDriver has already been closed.
 GET_SESSION_INTERRUPTED=Interrupted while waiting to get available session from the session pool.
 INCORRECT_TYPE=Unexpected type in result, expected: %s, received: %s.

--- a/src/main/resources/version.properties
+++ b/src/main/resources/version.properties
@@ -1,1 +1,1 @@
-project.version=0.2.0-beta
+project.version=1.0.2

--- a/src/test/software/amazon/qldb/MockQldbSessionClient.java
+++ b/src/test/software/amazon/qldb/MockQldbSessionClient.java
@@ -1,10 +1,10 @@
 /*
- * Copyright 2014-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at
  *
- * http://aws.amazon.com/apache2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
  * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
@@ -12,14 +12,14 @@
  */
 package software.amazon.qldb;
 
-import java.util.ArrayDeque;
-import java.util.Queue;
-
 import com.amazonaws.AmazonWebServiceRequest;
 import com.amazonaws.ResponseMetadata;
 import com.amazonaws.services.qldbsession.AmazonQLDBSession;
 import com.amazonaws.services.qldbsession.model.SendCommandRequest;
 import com.amazonaws.services.qldbsession.model.SendCommandResult;
+
+import java.util.ArrayDeque;
+import java.util.Queue;
 
 public class MockQldbSessionClient implements AmazonQLDBSession {
     private static class Holder {

--- a/src/test/software/amazon/qldb/MockResponses.java
+++ b/src/test/software/amazon/qldb/MockResponses.java
@@ -1,24 +1,16 @@
 /*
- * Copyright 2014-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at
  *
- * http://aws.amazon.com/apache2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
  * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
  * and limitations under the License.
  */
 package software.amazon.qldb;
-
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 import com.amazon.ion.IonValue;
 import com.amazon.ion.IonWriter;
@@ -32,8 +24,17 @@ import com.amazonaws.services.qldbsession.model.StartSessionResult;
 import com.amazonaws.services.qldbsession.model.StartTransactionResult;
 import com.amazonaws.services.qldbsession.model.ValueHolder;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 public class MockResponses {
     public static final String SESSION_TOKEN = "sessionToken";
+    public static final String REQUEST_ID = "requestId";
     public static final SendCommandResult ABORT_RESPONSE = addRequestId(new SendCommandResult());
     public static final StartSessionResult startSessionResult = new StartSessionResult().withSessionToken(SESSION_TOKEN);
     public static final SendCommandResult START_SESSION_RESPONSE =
@@ -85,7 +86,7 @@ public class MockResponses {
 
     private static SendCommandResult addRequestId(SendCommandResult result) {
         final Map<String, String> responseMap = new HashMap<>();
-        responseMap.put(ResponseMetadata.AWS_REQUEST_ID, "requestId");
+        responseMap.put(ResponseMetadata.AWS_REQUEST_ID, REQUEST_ID);
         responseMap.put(ResponseMetadata.AWS_EXTENDED_REQUEST_ID, "extRequestId");
         result.setSdkResponseMetadata(new ResponseMetadata(responseMap));
         return result;

--- a/src/test/software/amazon/qldb/TestBufferedResult.java
+++ b/src/test/software/amazon/qldb/TestBufferedResult.java
@@ -1,20 +1,16 @@
 /*
- * Copyright 2014-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at
  *
- * http://aws.amazon.com/apache2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
  * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
  * and limitations under the License.
  */
 package software.amazon.qldb;
-
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
 
 import com.amazon.ion.IonSystem;
 import com.amazon.ion.IonValue;
@@ -26,8 +22,9 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
-import software.amazon.qldb.BufferedResult;
-import software.amazon.qldb.Result;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
 
 public class TestBufferedResult {
     private static final IonSystem system = IonSystemBuilder.standard().build();

--- a/src/test/software/amazon/qldb/TestQldbDriver.java
+++ b/src/test/software/amazon/qldb/TestQldbDriver.java
@@ -1,10 +1,10 @@
 /*
- * Copyright 2014-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at
  *
- * http://aws.amazon.com/apache2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
  * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
@@ -12,18 +12,19 @@
  */
 package software.amazon.qldb;
 
-import java.util.concurrent.ExecutorService;
-
 import com.amazon.ion.system.IonSystemBuilder;
 import com.amazonaws.ClientConfigurationFactory;
 import com.amazonaws.services.qldbsession.AmazonQLDBSessionClientBuilder;
-
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
+
+import java.util.concurrent.ExecutorService;
 
 public class TestQldbDriver {
     private static final AmazonQLDBSessionClientBuilder CLIENT_BUILDER = AmazonQLDBSessionClientBuilder.standard()
@@ -36,6 +37,9 @@ public class TestQldbDriver {
     @Mock
     private AmazonQLDBSessionClientBuilder mockBuilder;
 
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
     @Before
     public void init() {
         MockitoAnnotations.initMocks(this);
@@ -45,24 +49,30 @@ public class TestQldbDriver {
     }
 
     // This is a test for QldbDriverBuilder
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testBuildWithBlankLedger() {
+        thrown.expect(IllegalArgumentException.class);
+
         QldbDriver.builder()
                 .withSessionClientBuilder(CLIENT_BUILDER)
                 .build();
     }
 
     // This is a test for QldbDriverBuilder
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testBuildWithNullClientBuilder() {
+        thrown.expect(IllegalArgumentException.class);
+
         QldbDriver.builder()
                 .withLedger(LEDGER)
                 .build();
     }
 
     // This is a test for QldbDriverBuilder
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testBuildWithOccConflictRetryLimitNegativeInt() {
+        thrown.expect(IllegalArgumentException.class);
+
         QldbDriver.builder()
                 .withRetryLimit(-1)
                 .build();
@@ -89,8 +99,10 @@ public class TestQldbDriver {
     }
 
     // This is a test for QldbDriverBuilder
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testBuildWithNullIonSystem() {
+        thrown.expect(IllegalArgumentException.class);
+
         QldbDriver.builder()
                 .withIonSystem(null)
                 .build();
@@ -107,8 +119,10 @@ public class TestQldbDriver {
     }
 
     // This is a test for QldbDriverBuilder
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testBuildWithReadAheadNegativeInt() {
+        thrown.expect(IllegalArgumentException.class);
+
         QldbDriver.builder()
                 .withReadAhead(-1)
                 .build();
@@ -125,8 +139,10 @@ public class TestQldbDriver {
     }
 
     // This is a test for QldbDriverBuilder
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testBuildWithReadAheadPositiveNullExecutor() {
+        thrown.expect(IllegalArgumentException.class);
+
         QldbDriver.builder()
                 .withReadAhead(1, null)
                 .build();
@@ -143,8 +159,10 @@ public class TestQldbDriver {
     }
 
     // This is a test for QldbDriverBuilder
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testBuildWithReadAheadLessThanTwo() {
+        thrown.expect(IllegalArgumentException.class);
+
         final QldbDriver.QldbDriverBuilder builder = QldbDriver.builder()
                 .withReadAhead(1)
                 .withSessionClientBuilder(CLIENT_BUILDER)
@@ -153,8 +171,10 @@ public class TestQldbDriver {
     }
 
     // This is a test for QldbDriverBuilder
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testBuildWithDefaultClientWithOccConflictRetryLimitNegativeInt() {
+        thrown.expect(IllegalArgumentException.class);
+
         QldbDriver.builder()
                 .withRetryLimit(-1)
                 .build();
@@ -170,7 +190,7 @@ public class TestQldbDriver {
         Assert.assertEquals(driver.getSession().getLedgerName(), LEDGER);
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testGetSessionWhenClosed() {
         mockClient.queueResponse(MockResponses.START_SESSION_RESPONSE);
         mockClient.queueResponse(MockResponses.endSessionResponse());
@@ -178,6 +198,9 @@ public class TestQldbDriver {
                 .withLedger(LEDGER)
                 .withSessionClientBuilder(mockBuilder)
                 .build();
+
+        thrown.expect(IllegalStateException.class);
+
         try {
             driver.getSession().close();
             driver.close();

--- a/src/test/software/amazon/qldb/TestResultHolder.java
+++ b/src/test/software/amazon/qldb/TestResultHolder.java
@@ -1,10 +1,10 @@
 /*
- * Copyright 2014-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at
  *
- * http://aws.amazon.com/apache2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
  * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
@@ -12,11 +12,10 @@
  */
 package software.amazon.qldb;
 
+import com.amazonaws.services.qldbsession.model.Page;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
-
-import com.amazonaws.services.qldbsession.model.Page;
 
 public class TestResultHolder {
     @Test

--- a/src/test/software/amazon/qldb/TestTableNameIterable.java
+++ b/src/test/software/amazon/qldb/TestTableNameIterable.java
@@ -1,16 +1,26 @@
 /*
- * Copyright 2014-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at
  *
- * http://aws.amazon.com/apache2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
  * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
  * and limitations under the License.
  */
 package software.amazon.qldb;
+
+import com.amazon.ion.IonStruct;
+import com.amazon.ion.IonSystem;
+import com.amazon.ion.IonValue;
+import com.amazon.ion.system.IonSystemBuilder;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -19,16 +29,11 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import com.amazon.ion.IonStruct;
-import com.amazon.ion.IonSystem;
-import com.amazon.ion.IonValue;
-import com.amazon.ion.system.IonSystemBuilder;
-import org.junit.Assert;
-import org.junit.Test;
-import org.mockito.Mockito;
-
 public class TestTableNameIterable {
     private static final IonSystem system = IonSystemBuilder.standard().build();
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void testEmptyResult() {
@@ -45,12 +50,14 @@ public class TestTableNameIterable {
         testRowResult(Arrays.asList("table1", "table2"));
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testIncorrectStructureNoStringResult() {
         final List<IonValue> ionTables = new ArrayList<>();
         final IonStruct struct = system.newEmptyStruct();
         struct.add("name", system.singleValue("table"));
         ionTables.add(struct);
+
+        thrown.expect(IllegalStateException.class);
 
         iterateTables(ionTables);
     }

--- a/src/test/software/amazon/qldb/TestTransactionExecutor.java
+++ b/src/test/software/amazon/qldb/TestTransactionExecutor.java
@@ -1,10 +1,10 @@
 /*
- * Copyright 2014-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at
  *
- * http://aws.amazon.com/apache2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
  * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
@@ -12,22 +12,24 @@
  */
 package software.amazon.qldb;
 
-import java.util.Collections;
-import java.util.List;
-
 import com.amazon.ion.IonSystem;
 import com.amazon.ion.IonValue;
 import com.amazon.ion.system.IonSystemBuilder;
 import com.amazonaws.AmazonClientException;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import software.amazon.qldb.exceptions.AbortException;
+
+import java.util.Collections;
+import java.util.List;
 
 public class TestTransactionExecutor {
     private static final IonSystem system = IonSystemBuilder.standard().build();
@@ -40,6 +42,9 @@ public class TestTransactionExecutor {
     @Mock
     private Transaction mockTxn;
 
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
     @Before
     public void init() {
         MockitoAnnotations.initMocks(this);
@@ -50,9 +55,12 @@ public class TestTransactionExecutor {
         txnExec = new TransactionExecutor(mockTxn);
     }
 
-    @Test(expected = AbortException.class)
+    @Test
     public void testAbortThrows() {
         Mockito.doThrow(new AmazonClientException("")).when(mockTxn).abort();
+
+        thrown.expect(AbortException.class);
+
         txnExec.abort();
     }
 

--- a/src/test/software/amazon/qldb/TestValidate.java
+++ b/src/test/software/amazon/qldb/TestValidate.java
@@ -1,10 +1,10 @@
 /*
- * Copyright 2014-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at
  *
- * http://aws.amazon.com/apache2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
  * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
@@ -12,43 +12,54 @@
  */
 package software.amazon.qldb;
 
+import org.junit.Rule;
 import org.junit.Test;
-
-import software.amazon.qldb.Validate;
+import org.junit.rules.ExpectedException;
 
 public class TestValidate {
-    @Test(expected = IllegalArgumentException.class)
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Test
     public void testNegativeIsNotNegative() {
+        thrown.expect(IllegalArgumentException.class);
+
         Validate.assertIsNotNegative(-1, "val");
     }
 
     @Test
     public void testPositiveIsNotNegative() {
-        Validate.assertIsNotNegative(1, "val");
+        software.amazon.qldb.Validate.assertIsNotNegative(1, "val");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testFalseIsTrue() {
-        Validate.assertIsTrue(false, "val");
+        thrown.expect(IllegalArgumentException.class);
+
+        software.amazon.qldb.Validate.assertIsTrue(false, "val");
     }
 
     @Test
     public void testTrueIsTrue() {
-        Validate.assertIsTrue(true, "val");
+        software.amazon.qldb.Validate.assertIsTrue(true, "val");
     }
 
     @Test
     public void testPoolLimitValid() {
-        Validate.assertPoolLimit(20, 19, "poolLimit");
+        software.amazon.qldb.Validate.assertPoolLimit(20, 19, "poolLimit");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testPoolLimitNegative() {
-        Validate.assertPoolLimit(20, -1, "poolLimit");
+        thrown.expect(IllegalArgumentException.class);
+
+        software.amazon.qldb.Validate.assertPoolLimit(20, -1, "poolLimit");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testPoolLimitExceedsConfig() {
-        Validate.assertPoolLimit(20, 21, "poolLimit");
+        thrown.expect(IllegalArgumentException.class);
+
+        software.amazon.qldb.Validate.assertPoolLimit(20, 21, "poolLimit");
     }
 }


### PR DESCRIPTION
- Bump version of the AWS SDK to 11.1.649
- Fix an issue that will make the driver throw an `InvalidSessionException` when executing a transaction. In the initial release of the driver, if a session becomes invalid while using the `PooledQldbSession`'s `execute` convenience methods, then the transaction will fail completely for the caller, as the `InvalidSessionException` is re-thrown. To prevent the caller from needing to write additional retry logic, the `execute` methods will now transparently replace an invalid session with a new one and retry the transaction but still be limited to the number of retries configured.