### PR TITLE
Fixed stylecheck CVE.

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -43,6 +43,12 @@
                   default="checkstyle-suppressions.xml"/>
     </module>
 
+    <!-- Enforce maximum line lengths. -->
+    <module name="LineLength">
+        <property name="max" value="130"/>
+        <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
+    </module>
+
     <module name="TreeWalker">
 
         <!-- Allow suppressing rules via comments. -->
@@ -67,12 +73,6 @@
             <property name="allowEscapesForControlCharacters" value="true"/>
             <property name="allowByTailComment" value="true"/>
             <property name="allowNonPrintableEscapes" value="true"/>
-        </module>
-
-        <!-- Enforce maximum line lengths. -->
-        <module name="LineLength">
-            <property name="max" value="130"/>
-            <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
         </module>
 
         <!-- Stars must not be used in import statements. -->
@@ -104,7 +104,7 @@
         <!-- For other language constructs, they must be defined on a separate line. -->
         <module name="RightCurly">
             <property name="id" value="RightCurlyAlone"/>
-            <property name="option" value="alone"/>
+            <property name="option" value="alone_or_singleline"/>
             <property name="tokens"
                       value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, STATIC_INIT, INSTANCE_INIT"/>
         </module>

--- a/pom.xml
+++ b/pom.xml
@@ -68,8 +68,8 @@
         <build.year>${maven.build.timestamp}</build.year>
         <jdkVersion>1.8</jdkVersion>
         <awssdk.version>1.11.649</awssdk.version>
-        <maven-checkstyle-plugin.version>2.17</maven-checkstyle-plugin.version>
-        <checkstyle.version>8.18</checkstyle.version>
+        <maven-checkstyle-plugin.version>3.1.1</maven-checkstyle-plugin.version>
+        <checkstyle.version>8.31</checkstyle.version>
     </properties>
 
     <dependencies>

--- a/src/main/java/software/amazon/qldb/BaseSyncQldbDriver.java
+++ b/src/main/java/software/amazon/qldb/BaseSyncQldbDriver.java
@@ -15,7 +15,6 @@ package software.amazon.qldb;
 
 import com.amazon.ion.IonSystem;
 import com.amazonaws.services.qldbsession.AmazonQLDBSession;
-
 import java.util.concurrent.ExecutorService;
 
 /**

--- a/src/main/java/software/amazon/qldb/PooledQldbDriver.java
+++ b/src/main/java/software/amazon/qldb/PooledQldbDriver.java
@@ -17,7 +17,6 @@ import com.amazon.ion.IonSystem;
 import com.amazon.ion.IonValue;
 import com.amazonaws.annotation.ThreadSafe;
 import com.amazonaws.services.qldbsession.AmazonQLDBSession;
-
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;


### PR DESCRIPTION
Upgrade stylecheck from 8.18 to 8.31 to fix CVE-2019-9658. Adjust rules which were not enabled previously.

*Issue #, if available:*

*Description of changes:*
Upgrade stylecheck from 8.18 to 8.31 to fix CVE-2019-9658.
Upgrade maven-stylecheck-plugin 2.17 to 3.1.1 to make it work with newer stylecheck version.
Moved *LineLength* out of the *TreeWalker* section since it is not supported in there with newer version.
Both *RightCurly* and *CustomImportOrder* rules were not enabled with previous version, but enabled now. Have to adjust the rule or code to make it pass.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
