### PR TITLE
Upgraded Mockito to make the repo work with JDK11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.2.17</version>
+            <version>3.3.3</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
The real issue was byte-buddy.

*Issue #, if available:*
#9 Tests fail with JDK11 and later versions
*Description of changes:*
Upgrade Mockito from 2.2.17 to 3.3.3, which bring up byte-buddy version to 1.10.5.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
