### PR TITLE
Fix exception handling on the QldbDriver

### DIFF
--- a/src/main/java/software/amazon/qldb/DefaultQldbTransactionBackoffStrategy.java
+++ b/src/main/java/software/amazon/qldb/DefaultQldbTransactionBackoffStrategy.java
@@ -53,7 +53,21 @@ public class DefaultQldbTransactionBackoffStrategy implements BackoffStrategy {
     DefaultQldbTransactionBackoffStrategy(final Duration baseDelay, final Duration maxBackoffTime, final Random random) {
         this.baseDelay = Validate.isNotNegative(baseDelay, "baseDelay");
         this.maxBackoffTime = Validate.isNotNegative(maxBackoffTime, "maxBackoffTime");
+
+        if (baseDelay.compareTo(maxBackoffTime) > 0) {
+            throw new IllegalArgumentException(String.format("%s cannot be greater than %s", "baseDelay", "maxBackoffTime"));
+        }
+
         this.random = random;
+    }
+
+    /**
+     * Constructor to create a Backoff Strategy but with custom baseDelay and cap backoff time.
+     * @param baseDelay The minimum amount of time to delay a retry.
+     * @param maxBackoffTime The maximum time to delay a retry.
+     */
+    public DefaultQldbTransactionBackoffStrategy(final Duration baseDelay, final Duration maxBackoffTime) {
+        this(baseDelay, maxBackoffTime, new Random());
     }
 
     /**

--- a/src/main/java/software/amazon/qldb/Executable.java
+++ b/src/main/java/software/amazon/qldb/Executable.java
@@ -28,8 +28,7 @@ public interface Executable {
      *              The PartiQL statement to be executed against QLDB.
      *
      * @return The result of executing the statement.
-     * @throws software.amazon.awssdk.awscore.exception.AwsServiceException if there is an error executing
-     * against QLDB.
+     * @throws software.amazon.awssdk.core.exception.SdkException if there is an error executing against QLDB.
      */
     Result execute(String statement);
 
@@ -42,7 +41,7 @@ public interface Executable {
      *              The parameters to be used with the PartiQL statement, for each ? placeholder in the statement.
      *
      * @return The result of executing the statement.
-     * @throws software.amazon.awssdk.awscore.exception.AwsServiceException if there is an error executing against QLDB.
+     * @throws software.amazon.awssdk.core.exception.SdkException if there is an error executing against QLDB.
      */
     Result execute(String statement, List<IonValue> parameters);
 
@@ -55,7 +54,7 @@ public interface Executable {
      *              The parameters to be used with the PartiQL statement, for each ? placeholder in the statement.
      *
      * @return The result of executing the statement.
-     * @throws software.amazon.awssdk.awscore.exception.AwsServiceException if there is an error executing against QLDB.
+     * @throws software.amazon.awssdk.core.exception.SdkException if there is an error executing against QLDB.
      */
     Result execute(String statement, IonValue... parameters);
 }

--- a/src/main/java/software/amazon/qldb/QldbDriver.java
+++ b/src/main/java/software/amazon/qldb/QldbDriver.java
@@ -72,7 +72,7 @@ public interface QldbDriver extends AutoCloseable {
      *              A lambda with no return value representing the block of code to be executed within the transaction.
      *              This cannot have any side effects as it may be invoked multiple times.
      *
-     * @throws software.amazon.awssdk.awscore.exception.AwsServiceException if there is an error executing against QLDB.
+     * @throws software.amazon.awssdk.core.exception.SdkException if there is an error executing against QLDB.
      */
     void execute(ExecutorNoReturn executor);
 
@@ -90,7 +90,7 @@ public interface QldbDriver extends AutoCloseable {
      *              A {@link RetryPolicy} that overrides the RetryPolicy set when creating the driver. The given retry policy
      *              will be used when retrying the transaction.
      * @throws TransactionAbortedException if the Executor lambda calls {@link TransactionExecutor#abort()}.
-     * @throws software.amazon.awssdk.awscore.exception.AwsServiceException if there is an error executing against QLDB.
+     * @throws software.amazon.awssdk.core.exception.SdkException if there is an error executing against QLDB.
      */
     void execute(ExecutorNoReturn executor, RetryPolicy retryPolicy);
 
@@ -110,7 +110,7 @@ public interface QldbDriver extends AutoCloseable {
      *         invalidated, including if the return value is an object which nests said {@link Result} instances within
      *         it.
      * @throws TransactionAbortedException if the Executor lambda calls {@link TransactionExecutor#abort()}.
-     * @throws software.amazon.awssdk.awscore.exception.AwsServiceException if there is an error executing against QLDB.
+     * @throws software.amazon.awssdk.core.exception.SdkException if there is an error executing against QLDB.
      */
     <T> T execute(Executor<T> executor);
 
@@ -137,7 +137,7 @@ public interface QldbDriver extends AutoCloseable {
      *         invalidated, including if the return value is an object which nests said {@link Result} instances within
      *         it.
      * @throws TransactionAbortedException if the Executor lambda calls {@link TransactionExecutor#abort()}.
-     * @throws software.amazon.awssdk.awscore.exception.AwsServiceException if there is an error executing against QLDB.
+     * @throws software.amazon.awssdk.core.exception.SdkException if there is an error executing against QLDB.
      */
     <T> T execute(Executor<T> executor, RetryPolicy retryPolicy);
 
@@ -147,7 +147,7 @@ public interface QldbDriver extends AutoCloseable {
      * @return The Iterable over the table names in the ledger.
      * @throws IllegalStateException if this QldbSession has been closed already, or if the transaction's commit
      *                               digest does not match the response from QLDB.
-     * @throws software.amazon.awssdk.awscore.exception.AwsServiceException if there is an error communicating with QLDB.
+     * @throws software.amazon.awssdk.core.exception.SdkException if there is an error communicating with QLDB.
      */
     Iterable<String> getTableNames();
 

--- a/src/main/java/software/amazon/qldb/StreamResult.java
+++ b/src/main/java/software/amazon/qldb/StreamResult.java
@@ -127,7 +127,7 @@ class StreamResult implements Result {
          * Get boolean indicating if there is a next value in the iterator.
          *
          * @return Boolean indicating whether or not there is a next value.
-         * @throws software.amazon.awssdk.awscore.exception.AwsServiceException if there is an error communicating with QLDB,
+         * @throws software.amazon.awssdk.core.exception.SdkException if there is an error communicating with QLDB,
          *      when trying to get the next page of results.
          */
         @Override
@@ -139,7 +139,7 @@ class StreamResult implements Result {
          * Get the next value in the iterator.
          *
          * @return The next IonValue resulting from the execution statement.
-         * @throws software.amazon.awssdk.awscore.exception.AwsServiceException if there is an error communicating with QLDB,
+         * @throws software.amazon.awssdk.core.exception.SdkException if there is an error communicating with QLDB,
          *      when trying to get the next page of results.
          */
         @Override

--- a/src/main/java/software/amazon/qldb/Transaction.java
+++ b/src/main/java/software/amazon/qldb/Transaction.java
@@ -26,13 +26,12 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.annotations.NotThreadSafe;
-import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.services.qldbsession.model.ExecuteStatementResult;
 import software.amazon.awssdk.services.qldbsession.model.InvalidSessionException;
 import software.amazon.awssdk.services.qldbsession.model.OccConflictException;
 import software.amazon.awssdk.utils.Validate;
 import software.amazon.qldb.exceptions.Errors;
-
 
 /**
  * <p>Interface that represents an active transaction with QLDB.</p>
@@ -89,7 +88,7 @@ class Transaction {
     /**
      * Abort the transaction and roll back any changes. Any open Results created by the transaction will be closed.
      *
-     * @throws software.amazon.awssdk.awscore.exception.AwsServiceException if there is an error communicating with QLDB.
+     * @throws software.amazon.awssdk.core.exception.SdkException if there is an error communicating with QLDB.
      */
     void abort() {
         if (!isClosed.get()) {
@@ -104,8 +103,8 @@ class Transaction {
     void close() {
         try {
             abort();
-        } catch (AwsServiceException ace) {
-            logger.warn("Ignored error aborting transaction when closing.", ace);
+        } catch (SdkException se) {
+            logger.warn("Ignored error aborting transaction when closing.", se);
         }
     }
 
@@ -119,7 +118,7 @@ class Transaction {
      * @throws IllegalStateException if the transaction has been committed or aborted already, or if the returned commit
      *                               digest from QLDB does not match.
      * @throws OccConflictException if an OCC conflict has been detected within the transaction.
-     * @throws software.amazon.awssdk.awscore.exception.AwsServiceException if there is an error communicating with QLDB.
+     * @throws software.amazon.awssdk.core.exception.SdkException if there is an error communicating with QLDB.
      */
     void commit() {
         try {
@@ -135,9 +134,9 @@ class Transaction {
         } catch (InvalidSessionException ise) {
             // Avoid sending abort since we know session is dead.
             throw ise;
-        } catch (AwsServiceException ace) {
+        } catch (SdkException se) {
             close();
-            throw ace;
+            throw se;
         } finally {
             internalClose();
         }

--- a/src/test/software/amazon/qldb/DefaultQldbTransactionBackoffStrategyTest.java
+++ b/src/test/software/amazon/qldb/DefaultQldbTransactionBackoffStrategyTest.java
@@ -1,0 +1,52 @@
+package software.amazon.qldb;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+
+public class DefaultQldbTransactionBackoffStrategyTest {
+
+    @Test
+    public void testNullBaseDuration() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            new DefaultQldbTransactionBackoffStrategy(null, null);
+        });
+    }
+
+    @Test
+    public void testNullCapDuration() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            new DefaultQldbTransactionBackoffStrategy(Duration.ofMillis(1), null);
+        });
+    }
+
+    @Test
+    public void testNegativeBaseDuration() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            new DefaultQldbTransactionBackoffStrategy(Duration.ofMillis(-11), Duration.ofMillis(1));
+        });
+    }
+
+    @Test
+    public void testNegativeCapDuration() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            new DefaultQldbTransactionBackoffStrategy(Duration.ofMillis(1), Duration.ofMillis(-1));
+        });
+    }
+
+    @Test
+    public void testBaseDurationLargerThanCapDuration() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            new DefaultQldbTransactionBackoffStrategy(Duration.ofMillis(200), Duration.ofMillis(1));
+        });
+    }
+
+    @Test
+    public void testBaseDurationSameAsCapDuration() {
+        assertDoesNotThrow(() -> {
+            new DefaultQldbTransactionBackoffStrategy(Duration.ofMillis(1), Duration.ofMillis(1));
+        });
+    }
+}

--- a/src/test/software/amazon/qldb/QldbDriverImplTest.java
+++ b/src/test/software/amazon/qldb/QldbDriverImplTest.java
@@ -15,7 +15,6 @@ package software.amazon.qldb;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -44,7 +43,8 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
-import software.amazon.awssdk.core.exception.SdkServiceException;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.services.qldbsession.QldbSessionClientBuilder;
 import software.amazon.awssdk.services.qldbsession.model.InvalidSessionException;
 import software.amazon.awssdk.services.qldbsession.model.OccConflictException;
@@ -184,7 +184,7 @@ public class QldbDriverImplTest {
 
     @ParameterizedTest
     @MethodSource("exceptionProvider")
-    public void testExecuteCustomPolicy(SdkServiceException exception) {
+    public void testExecuteCustomPolicy(SdkException exception) {
         RetryPolicy driverRetryPolicy = spy(RetryPolicy.maxRetries(3));
         qldbDriverImpl = QldbDriver.builder()
                                    .sessionClientBuilder(mockBuilder)
@@ -211,13 +211,13 @@ public class QldbDriverImplTest {
         verify(customRetryPolicy, times(1)).maxRetries();
     }
 
-    static Stream<SdkServiceException> exceptionProvider () {
-        return Stream.of(AwsServiceException
+    static Stream<SdkException> exceptionProvider () {
+        return Stream.of(SdkClientException
                       .builder()
                       .message("Transient issue")
                       .cause(new SocketTimeoutException())
                       .build(),
-                  OccConflictException.builder().message("Msg1").build()
+                         OccConflictException.builder().message("Msg1").build()
                   );
     }
 

--- a/src/test/software/amazon/qldb/QldbSessionTest.java
+++ b/src/test/software/amazon/qldb/QldbSessionTest.java
@@ -12,16 +12,19 @@
  */
 package software.amazon.qldb;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static software.amazon.qldb.MockResponses.SESSION_TOKEN;
 
 import com.amazon.ion.IonSystem;
 import com.amazon.ion.IonValue;
@@ -29,6 +32,7 @@ import com.amazon.ion.system.IonSystemBuilder;
 import java.io.IOException;
 import java.net.SocketTimeoutException;
 import java.nio.ByteBuffer;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
@@ -41,7 +45,10 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.core.exception.SdkServiceException;
+import software.amazon.awssdk.services.qldbsession.model.AbortTransactionRequest;
 import software.amazon.awssdk.services.qldbsession.model.BadRequestException;
 import software.amazon.awssdk.services.qldbsession.model.InvalidSessionException;
 import software.amazon.awssdk.services.qldbsession.model.OccConflictException;
@@ -82,7 +89,7 @@ public class QldbSessionTest {
         client = new MockQldbSessionClient();
         client.queueResponse(MockResponses.START_SESSION_RESPONSE);
         mockSession = Session.startSession(LEDGER, client);
-        qldbSession = new QldbSession(mockSession, retryPolicy, READ_AHEAD, system, null);
+        qldbSession = new QldbSession(mockSession, READ_AHEAD, system, null);
     }
 
     @Test
@@ -116,7 +123,7 @@ public class QldbSessionTest {
         assertThrows(InvalidSessionException.class, () -> {
             QldbSession qldbSession = null;
             try {
-                qldbSession = new QldbSession(mockSession, retryPolicy, READ_AHEAD, system, null);
+                qldbSession = new QldbSession(mockSession, READ_AHEAD, system, null);
                 qldbSession.execute(txn -> null, null, new ExecutionContext());
             } finally {
                 assertTrue(client.isQueueEmpty());
@@ -129,6 +136,7 @@ public class QldbSessionTest {
     @DisplayName("execute - SHOULD not call the executor lambda WHEN QLDB fails to start a transaction")
     public void testStartTransactionError() {
         client.queueResponse(QldbSessionException.builder().message("an error").build());
+        client.queueResponse(MockResponses.ABORT_RESPONSE);
 
         assertThrows(QldbSessionException.class, () -> {
             // StartTransaction is called at the beginning of the execute method
@@ -223,7 +231,7 @@ public class QldbSessionTest {
     @DisplayName("execute - SHOULD retry generic server side failures WHEN QLDB executes a transaction")
     public void testExecuteExecutorLambdaWithSdkServiceExceptions() throws IOException {
         // This exception should be retried.
-        final AwsServiceException exception1 = AwsServiceException
+        final SdkClientException exception1 = SdkClientException
             .builder()
             .message("Error 1")
             .cause(new NoHttpResponseException("cause"))
@@ -231,7 +239,7 @@ public class QldbSessionTest {
         queueTxnExecError(exception1);
 
         // This exception should be retried.
-        final AwsServiceException exception2 = AwsServiceException
+        final SdkClientException exception2 = SdkClientException
             .builder()
             .message("Error 2")
             .cause(new SocketTimeoutException("cause"))
@@ -258,10 +266,10 @@ public class QldbSessionTest {
     }
 
     @Test
-    @DisplayName("execute - SHOULD retry generic server side failures up to a limit WHEN QLDB executes a transaction")
-    public void testExecuteExecutorLambdaWithSdkServiceExceptionsExceedRetry() throws IOException {
+    @DisplayName("execute - SHOULD retry generic client failures up to a limit WHEN QLDB executes a transaction")
+    public void testExecuteExecutorLambdaWithSdkClientExceptionExceedRetry() throws IOException {
         for (int i = 0; i < RETRY_LIMIT + 1; ++i) {
-            final AwsServiceException exception = AwsServiceException
+            final SdkClientException exception = SdkClientException
                 .builder()
                 .message("Error")
                 .cause(new NoHttpResponseException("cause"))
@@ -269,7 +277,7 @@ public class QldbSessionTest {
             queueTxnExecError(exception);
         }
 
-        assertThrows(AwsServiceException.class, () -> {
+        assertThrows(SdkClientException.class, () -> {
             try {
                 qldbSession.execute(txnExecutor -> {
                     Result result = txnExecutor.execute(statement);
@@ -290,7 +298,7 @@ public class QldbSessionTest {
     public void testExecuteStartTxnWithInvalidSessionException() {
         // GIVEN
         RetryPolicy retryPolicy = spy(RetryPolicy.none());
-        qldbSession = new QldbSession(mockSession, retryPolicy, READ_AHEAD, system, null);
+        qldbSession = new QldbSession(mockSession, READ_AHEAD, system, null);
         // Add an ISE when starting a txn
         final InvalidSessionException exception = InvalidSessionException.builder().message("").build();
         client.queueResponse(exception);
@@ -319,7 +327,7 @@ public class QldbSessionTest {
         client = new MockQldbSessionClient();
         client.queueResponse(MockResponses.START_SESSION_RESPONSE);
         mockSession = Session.startSession(LEDGER, client);
-        qldbSession = new QldbSession(mockSession, retryPolicy, READ_AHEAD, system, null);
+        qldbSession = new QldbSession(mockSession, READ_AHEAD, system, null);
 
         // Add an ISE when executing a txn
         final InvalidSessionException exception = InvalidSessionException.builder().message("").build();
@@ -412,7 +420,7 @@ public class QldbSessionTest {
         client = spy(new MockQldbSessionClient());
         client.queueResponse(MockResponses.START_SESSION_RESPONSE);
         mockSession = Session.startSession(LEDGER, client);
-        qldbSession = new QldbSession(mockSession, retryPolicy, READ_AHEAD, system, null);
+        qldbSession = new QldbSession(mockSession, READ_AHEAD, system, null);
         client.queueResponse(MockResponses.startTxnResponse("id"));
         client.queueResponse(MockResponses.executeResponse(ionList));
         client.queueResponse(MockResponses.ABORT_RESPONSE);
@@ -435,9 +443,14 @@ public class QldbSessionTest {
     @Test
     @DisplayName("execute - SHOULD retry WHEN starting a transaction QLDB throws a BadRequestException")
     public void testRetryExecuteWithTransactionAlreadyOpenException() throws IOException {
-        // BadRequestException on start transaction if the transaction somehow is already open
+        client = spy(new MockQldbSessionClient());
+        client.queueResponse(MockResponses.START_SESSION_RESPONSE);
+        mockSession = Session.startSession(LEDGER, client);
+        qldbSession = new QldbSession(mockSession, READ_AHEAD, system, null);
+
         final BadRequestException exception = BadRequestException.builder().message("Transaction already open").build();
         client.queueResponse(exception);
+        client.queueResponse(MockResponses.ABORT_RESPONSE);
 
         // Then enqueue a set of successful operations to start, execute and commit the txn
         String txnId = "id";
@@ -452,6 +465,10 @@ public class QldbSessionTest {
         }, retryPolicy, new ExecutionContext());
 
         verify(retryPolicy, times(1)).backoffStrategy();
+        final SendCommandRequest abortRequest =
+            SendCommandRequest.builder().sessionToken(SESSION_TOKEN).abortTransaction(AbortTransactionRequest.builder().build()).build();
+        verify(client, times(1)).sendCommand(
+             eq(abortRequest));
     }
 
     @Test
@@ -459,10 +476,11 @@ public class QldbSessionTest {
     public void testExecuteWithTransactionAlreadyOpenExceptionAndRetryLimitExceeded() throws IOException {
         RetryPolicy retryPolicy = spy(RetryPolicy.none());
 
-        qldbSession = new QldbSession(mockSession, retryPolicy, READ_AHEAD, system, null);
+        qldbSession = new QldbSession(mockSession, READ_AHEAD, system, null);
         // BadRequestException on start transaction if the transaction somehow is already open
         final BadRequestException exception = BadRequestException.builder().message("Transaction already open").build();
         client.queueResponse(exception);
+        client.queueResponse(MockResponses.ABORT_RESPONSE);
 
         assertThrows(BadRequestException.class, () -> {
             qldbSession.execute(txnExecutor -> {
@@ -471,20 +489,21 @@ public class QldbSessionTest {
         });
 
         verify(retryPolicy, never()).backoffStrategy();
+
     }
 
     @Test
     @DisplayName("execute - SHOULD close transaction WHEN QLDB fails to execute a statement")
     public void testInternalExecuteWithError() {
         client.queueResponse(MockResponses.startTxnResponse("id"));
-        client.queueResponse(AwsServiceException.builder().message("an Error1").build());
+        client.queueResponse(SdkClientException.builder().message("an Error1").build());
         client.queueResponse(MockResponses.ABORT_RESPONSE);
 
-        assertThrows(AwsServiceException.class, () -> {
+        assertThrows(SdkClientException.class, () -> {
             try {
                 qldbSession.execute(txn -> {
                     return txn.execute(statement);
-                }, retryPolicy, new ExecutionContext());
+                }, RetryPolicy.none(), new ExecutionContext());
             } finally {
                 assertTrue(client.isQueueEmpty());
             }
@@ -492,13 +511,33 @@ public class QldbSessionTest {
     }
 
     @Test
-    @DisplayName("execute - SHOULD bubble up exception WHEN QLDB fails to abort transaction")
+    @DisplayName("execute - SHOULD not bubble up exception WHEN QLDB fails to abort transaction")
     public void testInternalExecuteWithErrorAndErrorOnAbort() {
         client.queueResponse(MockResponses.startTxnResponse("id"));
-        client.queueResponse(AwsServiceException.builder().message("an Error1").build());
-        client.queueResponse(AwsServiceException.builder().message("an Error 2").build());
+        final SdkClientException executionException = SdkClientException.builder().message("an Error1").build();
+        client.queueResponse(executionException);
+        client.queueResponse(SdkClientException.builder().message("an Error 2").build());
 
-        assertThrows(AwsServiceException.class, () -> {
+        try {
+            qldbSession.execute(txn -> txn.execute(statement), RetryPolicy.none(), new ExecutionContext());
+        }  catch(SdkClientException e) {
+            assertTrue(executionException == e);
+        } finally {
+            assertTrue(client.isQueueEmpty());
+        }
+    }
+
+    @Test
+    @DisplayName("execute - SHOULD delay zero ms WHEN backoff strategy is null")
+    public void testNullSleepTime() throws IOException {
+        client.queueResponse(MockResponses.startTxnResponse("id"));
+        client.queueResponse(SdkClientException.builder().message("an Error1").cause(new SocketTimeoutException()).build());
+        client.queueResponse(MockResponses.ABORT_RESPONSE);
+
+        queueTxnExecCommit(ionList, statement, Collections.emptyList());
+        retryPolicy = new RetryPolicy(retryPolicyContext -> null, 1);
+
+        assertDoesNotThrow(() -> {
             try {
                 qldbSession.execute(txn -> txn.execute(statement), retryPolicy, new ExecutionContext());
             } finally {
@@ -507,6 +546,24 @@ public class QldbSessionTest {
         });
     }
 
+    @Test
+    @DisplayName("execute - SHOULD delay zero ms WHEN backoff strategy is negative")
+    public void testNegativeSleepTime() throws IOException {
+        client.queueResponse(MockResponses.startTxnResponse("id"));
+        client.queueResponse(SdkClientException.builder().message("an Error1").cause(new SocketTimeoutException()).build());
+        client.queueResponse(MockResponses.ABORT_RESPONSE);
+
+        queueTxnExecCommit(ionList, statement, Collections.emptyList());
+        retryPolicy = new RetryPolicy(retryPolicyContext -> Duration.ofMillis(-1), 1);
+
+        assertDoesNotThrow(() -> {
+            try {
+                qldbSession.execute(txn -> txn.execute(statement), retryPolicy, new ExecutionContext());
+            } finally {
+                assertTrue(client.isQueueEmpty());
+            }
+        });
+    }
 
     private static <E> void compareIterators(Iterator<E> iterator1, Iterator<E> iterator2) {
         while (iterator2.hasNext() || iterator1.hasNext()) {
@@ -530,7 +587,7 @@ public class QldbSessionTest {
         client.queueResponse(OccConflictException.builder().message("An OCC Exception").build());
     }
 
-    public void queueTxnExecError(SdkServiceException ace) throws IOException {
+    public void queueTxnExecError(SdkException ace) throws IOException {
         client.queueResponse(MockResponses.startTxnResponse("id"));
         client.queueResponse(MockResponses.executeResponse(ionList));
         client.queueResponse(ace);

--- a/src/test/software/amazon/qldb/TransactionTest.java
+++ b/src/test/software/amazon/qldb/TransactionTest.java
@@ -33,6 +33,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.exception.SdkServiceException;
 import software.amazon.awssdk.services.qldbsession.model.CommitTransactionResult;
 import software.amazon.awssdk.services.qldbsession.model.ExecuteStatementResult;
@@ -161,18 +162,18 @@ public class TransactionTest {
 
     @Test
     public void testCommitExceptionAbortException() {
-        final SdkServiceException ace1 = SdkServiceException.builder().message("").build();
-        final SdkServiceException ace2 = SdkServiceException.builder().message("").build();
+        final SdkClientException se1 = SdkClientException.builder().message("").build();
+        final SdkClientException se2 = SdkClientException.builder().message("").build();
 
-        Mockito.when(mockSession.sendCommit(ArgumentMatchers.anyString(), ArgumentMatchers.any())).thenThrow(ace1);
-        Mockito.when(mockSession.sendAbort()).thenThrow(ace2);
+        Mockito.when(mockSession.sendCommit(ArgumentMatchers.anyString(), ArgumentMatchers.any())).thenThrow(se1);
+        Mockito.when(mockSession.sendAbort()).thenThrow(se2);
 
-        assertThrows(SdkServiceException.class, () -> {
+        assertThrows(SdkClientException.class, () -> {
             try {
                 txn.commit();
-            } catch (SdkServiceException ace) {
-                assertEquals(ace, ace1);
-                throw ace;
+            } catch (SdkClientException se) {
+                assertEquals(se, se1);
+                throw se;
             } finally {
                 assertTrue(txn.getIsClosed().get());
             }


### PR DESCRIPTION
*Description of changes:*

This change aims to fix the issue where the client side exceptions
thrown by the AWS SDK for Java v2 were not retried. These exceptions
mean that there was a failure from the client communicating with QLDB
hence they can be retried.

Additionally, adding some defensive code around the backoff strategy
result.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
