### PR TITLE
Fix infinite retry on transaction expiry.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# [2.0.0-rc.2](https://github.com/awslabs/amazon-qldb-driver-java/releases/tag/v2.0.0-rc.2)
+
+#### Bug Fixes:
+* Fixed bug which leads to infinite number of retries when a transaction expires.
+* Fixed bug which causes transaction to remain open when an unknown exception is thrown 
+inside execute.
+
+
 # [2.0.0-rc.1](https://github.com/awslabs/amazon-qldb-driver-java/releases/tag/v2.0.0-rc.1) 
 
 We are adding new changes to the QLDB Driver for Java. However Java driver 1.x will

--- a/src/main/java/software/amazon/qldb/QldbDriverImpl.java
+++ b/src/main/java/software/amazon/qldb/QldbDriverImpl.java
@@ -140,6 +140,10 @@ class QldbDriverImpl implements QldbDriver {
                 qldbSession = getSession();
                 return qldbSession.execute(executor, retryPolicy, executionContext);
             } catch (final InvalidSessionException ise) {
+                if (ise.getMessage().matches("Transaction .* has expired")) {
+                    logger.debug("Encountered Transaction expiry. Error {}", ise.getMessage());
+                    throw ise;
+                }
                 logger.debug("Retrying with another session. Error {}", ise.getMessage());
             } finally {
                 if (qldbSession != null) {

--- a/src/main/java/software/amazon/qldb/QldbSession.java
+++ b/src/main/java/software/amazon/qldb/QldbSession.java
@@ -30,7 +30,6 @@ import software.amazon.awssdk.services.qldbsession.model.OccConflictException;
 import software.amazon.awssdk.services.qldbsession.model.QldbSessionException;
 import software.amazon.awssdk.services.qldbsession.model.StartTransactionResult;
 import software.amazon.awssdk.utils.Validate;
-import software.amazon.qldb.exceptions.TransactionAbortedException;
 import software.amazon.qldb.exceptions.TransactionAlreadyOpenException;
 
 /**
@@ -95,9 +94,6 @@ class QldbSession {
                     throw (BadRequestException) taoe.getCause();
                 }
                 logger.debug("Retrying the transaction. {} ", taoe.getMessage());
-            } catch (TransactionAbortedException ae) {
-                noThrowAbort(transaction);
-                throw ae;
             } catch (InvalidSessionException ise) {
                 if (transaction != null) {
                     logger.warn("Transaction {} expired while executing. Cause {} ", transaction.getTransactionId(),
@@ -128,6 +124,9 @@ class QldbSession {
                 if (executionContext.retryAttempts() >= retryPolicy.maxRetries()) {
                     throw sce;
                 }
+            } catch (Exception e) {
+                noThrowAbort(transaction);
+                throw e;
             }
             executionContext.increaseAttempt();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes the case where an infinite retry occurs on a
    transaction expiry and throws back exception instead.
Also abort transaction on unknown exception

## Motivation and Context
Added context in Description

## Testing
Unit tests and Integration tests ran successfully.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] I have read the **CONTRIBUTING** document [Currently not accepting contributions]-->
- [ ] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**


## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
