### PR TITLE
Fix failing integration tests

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -5,17 +5,17 @@ name: Java CI with Maven
 
 on:
   push:
-    branches: [ master, v1.x ]
+    branches: [ master]
   pull_request:
-    branches: [ master, v1.x ]
+    branches: [ master]
 
 jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy: 
       matrix : 
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        java: [8, 11, 14-ea]
+        os: [ubuntu-latest, windows-latest]
+        java: [8, 11]
     
     steps:
     - uses: actions/checkout@v2
@@ -23,5 +23,11 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: ${{ matrix.java }}
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: us-east-1
     - name: Build with Maven
-      run: mvn -B package --file pom.xml
+      run: mvn -B package --file pom.xml -D region=us-east-1 -D ledgerSuffix=${{ matrix.java}}-${{ matrix.os }}

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <maven.pmd.plugin.version>3.11.0</maven.pmd.plugin.version>
         <maven.site.plugin.version>3.7.1</maven.site.plugin.version>
         <maven.source.plugin.version>3.0.1</maven.source.plugin.version>
-        <maven.surefire.plugin.version>3.0.0-M4</maven.surefire.plugin.version>
+        <maven.surefire.plugin.version>3.0.0-M5</maven.surefire.plugin.version>
         <mockito.core.version>3.3.3</mockito.core.version>
         <nexus.staging.maven.plugin.version>1.6.7</nexus.staging.maven.plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/test/software/amazon/qldb/integrationtests/IonTypesIntegTest.java
+++ b/src/test/software/amazon/qldb/integrationtests/IonTypesIntegTest.java
@@ -52,11 +52,11 @@ public class IonTypesIntegTest {
 
     @BeforeAll
     private static void setup() throws InterruptedException {
-        ledgerManager = new LedgerManager(Constants.LEDGER_NAME, System.getProperty("region"));
+        ledgerManager = new LedgerManager(Constants.LEDGER_NAME+System.getProperty("ledgerSuffix"), System.getProperty("region"));
 
         ledgerManager.runCreateLedger();
 
-        driver = ledgerManager.createQldbDriver(Constants.DEFAULT, Constants.DEFAULT);
+        driver = ledgerManager.createQldbDriver(Constants.DEFAULT, Constants.RETRY_LIMIT);
 
         // Create table
         String createTableQuery = String.format("CREATE TABLE %s", Constants.TABLE_NAME);
@@ -71,7 +71,6 @@ public class IonTypesIntegTest {
                 return count;
             });
         assertEquals(1, createTableCount);
-
         Iterable<String> result = driver.getTableNames();
         for (String tableName : result) {
             assertEquals(Constants.TABLE_NAME, tableName);


### PR DESCRIPTION
Integration tests were failing because
the tests were asserting incorrect datatypes.
Also some test were failing due to OCCs since
the retryLimit was set to -1 which meant that
there will be no retries. This commit fixes it.
