### PR TITLE
Add execution stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 2.1.0
+Add support for obtaining basic server-side statistics on individual statement executions.
+
+## :tada: Enhancements
+* Added `IOUsage` and `TimingInformation` classes to provide server-side execution statistics
+   * IOUsage provides `long getReadIOs()`
+   * TimingInformation provides `long getProcessingTimeMilliseconds()`
+   * Added `IOUsage getConsumedIOs()` and `TimingInformation getTimingInformation()` to the `Result` interface implemented by `BufferedResult` and `StreamResult`
+   * `IOUsage getConsumedIOs()` and `TimingInformation getTimingInformation()` methods are stateful, meaning the statistics returned by them reflect the state at the time of method execution
+
 # [2.0.0](https://github.com/awslabs/amazon-qldb-driver-java/releases/tag/v2.0.0)
 This is a public and generally available(GA) release of the driver, and this version can be used in production applications.
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>software.amazon.qldb</groupId>
     <artifactId>amazon-qldb-driver-java</artifactId>
-    <version>2.0.0</version>
+    <version>2.1.0</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
@@ -63,7 +63,7 @@
     </distributionManagement>
 
     <properties>
-        <aws.java.sdk.version>2.13.18</aws.java.sdk.version>
+        <aws.java.sdk.version>2.15.51</aws.java.sdk.version>
         <build.year>${maven.build.timestamp}</build.year>
         <checkstyle.version>8.29</checkstyle.version>
         <findbugs.maven.plugin.version>3.0.5</findbugs.maven.plugin.version>
@@ -355,7 +355,7 @@
                 <artifactId>maven-pmd-plugin</artifactId>
                 <version>${maven.pmd.plugin.version}</version>
                 <configuration>
-                    <linkXref>true</linkXref>
+                    <linkXRef>true</linkXRef>
                     <sourceEncoding>utf-8</sourceEncoding>
                     <minimumTokens>100</minimumTokens>
                 </configuration>

--- a/src/main/java/software/amazon/qldb/BufferedResult.java
+++ b/src/main/java/software/amazon/qldb/BufferedResult.java
@@ -31,6 +31,8 @@ import java.util.List;
  */
 class BufferedResult implements Result {
     private final List<IonValue> bufferedValues;
+    private final IOUsage ioUsage;
+    private final TimingInformation timingInfo;
 
     /**
      * Constructor for the result which buffers into the memory the supplied result before closing it.
@@ -41,12 +43,34 @@ class BufferedResult implements Result {
     BufferedResult(Result result) {
         final List<IonValue> tempValues = new ArrayList<>();
         result.iterator().forEachRemaining(tempValues::add);
-        bufferedValues = Collections.unmodifiableList(tempValues);
+        this.bufferedValues = Collections.unmodifiableList(tempValues);
+        this.ioUsage = result.getConsumedIOs();
+        this.timingInfo = result.getTimingInformation();
     }
 
     @Override
     public boolean isEmpty() {
         return bufferedValues.isEmpty();
+    }
+
+    /**
+     * Gets the IOUsage statistics for the current statement.
+     *
+     * @return The current IOUsage statistics.
+     */
+    @Override
+    public IOUsage getConsumedIOs() {
+        return ioUsage;
+    }
+
+    /**
+     * Gets the server side timing information for the current statement.
+     *
+     * @return The current TimingInformation statistics.
+     */
+    @Override
+    public TimingInformation getTimingInformation() {
+        return timingInfo;
     }
 
     @Override

--- a/src/main/java/software/amazon/qldb/IOUsage.java
+++ b/src/main/java/software/amazon/qldb/IOUsage.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package software.amazon.qldb;
+
+/**
+ * IOUsage class containing metrics for the amount of IO requests.
+ */
+public class IOUsage {
+    private final long readIOs;
+    private final long writeIOs;
+
+    IOUsage(long readIOs, long writeIOs) {
+        this.readIOs = readIOs;
+        this.writeIOs = writeIOs;
+    }
+
+    IOUsage(software.amazon.awssdk.services.qldbsession.model.IOUsage ioUsage) {
+        this.readIOs = ioUsage.readIOs();
+        this.writeIOs = ioUsage.writeIOs();
+    }
+
+    public long getReadIOs() {
+        return readIOs;
+    }
+
+    long getWriteIOs() {
+        return writeIOs;
+    }
+}

--- a/src/main/java/software/amazon/qldb/QldbHash.java
+++ b/src/main/java/software/amazon/qldb/QldbHash.java
@@ -167,7 +167,7 @@ public class QldbHash {
      */
     // CHECKSTYLE:OFF: DeclarationOrder - Implement comparator as lambda conflicts with checkstyle
     private static Comparator<byte[]> hashComparator = (h1, h2) -> {
-    //CHECKSTYLE:ON: DeclarationOrder
+        // CHECKSTYLE:ON: DeclarationOrder
         if (h1.length != 32 || h2.length != 32) {
             throw new IllegalArgumentException("Invalid hash");
         }

--- a/src/main/java/software/amazon/qldb/Result.java
+++ b/src/main/java/software/amazon/qldb/Result.java
@@ -28,4 +28,18 @@ public interface Result extends Iterable<IonValue> {
      * @return True if the result contains no documents; false otherwise.
      */
     boolean isEmpty();
+
+    /**
+     * Gets the IOUsage statistics for the current statement.
+     *
+     * @return The current IOUsage statistics.
+     */
+    IOUsage getConsumedIOs();
+
+    /**
+     * Gets the server side timing information for the current statement.
+     *
+     * @return The current TimingInformation statistics.
+     */
+    TimingInformation getTimingInformation();
 }

--- a/src/main/java/software/amazon/qldb/TimingInformation.java
+++ b/src/main/java/software/amazon/qldb/TimingInformation.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package software.amazon.qldb;
+
+/**
+ * TimingInformation class containing metrics on server-side processing time for requests.
+ */
+public class TimingInformation {
+    private final long processingTimeMilliseconds;
+
+    TimingInformation(long processingTimeMilliseconds) {
+        this.processingTimeMilliseconds = processingTimeMilliseconds;
+    }
+
+    TimingInformation(software.amazon.awssdk.services.qldbsession.model.TimingInformation timingInfo) {
+        this.processingTimeMilliseconds = timingInfo.processingTimeMilliseconds();
+    }
+
+    public long getProcessingTimeMilliseconds() {
+        return this.processingTimeMilliseconds;
+    }
+}

--- a/src/main/java/software/amazon/qldb/Transaction.java
+++ b/src/main/java/software/amazon/qldb/Transaction.java
@@ -152,7 +152,7 @@ class Transaction {
 
         setTransactionHash(dot(getTransactionHash(), statement, parameters, ionSystem));
         final ExecuteStatementResult executeStatementResult = session.sendExecute(statement, parameters, txnId);
-        final StreamResult result = new StreamResult(session, executeStatementResult.firstPage(), txnId,
+        final StreamResult result = new StreamResult(session, executeStatementResult, txnId,
                 readAheadBufferCount, ionSystem, executorService);
         results.add(result);
         return result;

--- a/src/test/software/amazon/qldb/BufferedResultTest.java
+++ b/src/test/software/amazon/qldb/BufferedResultTest.java
@@ -33,6 +33,9 @@ public class BufferedResultTest {
 
     private final List<IonValue> bufferedValue = Collections.singletonList(system.singleValue("myValue"));
 
+    private static final IOUsage testIO = new IOUsage(1, 2);
+    private static final TimingInformation testTiming = new TimingInformation(100);
+
     @Mock
     private Result mockResult;
 
@@ -43,6 +46,8 @@ public class BufferedResultTest {
     public void init() {
         MockitoAnnotations.initMocks(this);
         Mockito.when(mockResult.iterator()).thenReturn(bufferedValue.iterator());
+        Mockito.when(mockResult.getConsumedIOs()).thenReturn(testIO);
+        Mockito.when(mockResult.getTimingInformation()).thenReturn(testTiming);
     }
 
     @Test
@@ -56,6 +61,13 @@ public class BufferedResultTest {
     public void testIsEmptyWhenNotEmpty() {
         final BufferedResult bufferedResult = new BufferedResult(mockResult);
         assertFalse(bufferedResult.isEmpty());
+    }
+
+    @Test
+    public void testBufferResultGetsMetrics() {
+        final BufferedResult bufferedResult = new BufferedResult(mockResult);
+        assertEquals(testIO, bufferedResult.getConsumedIOs());
+        assertEquals(testTiming, bufferedResult.getTimingInformation());
     }
 
     @Test

--- a/src/test/software/amazon/qldb/ResultRetrieverTest.java
+++ b/src/test/software/amazon/qldb/ResultRetrieverTest.java
@@ -66,6 +66,18 @@ public class ResultRetrieverTest {
     @Mock
     private FetchPageResult mockFetchPage;
 
+    @Mock
+    private software.amazon.awssdk.services.qldbsession.model.IOUsage mockConsumedIOs;
+
+    @Mock
+    private software.amazon.awssdk.services.qldbsession.model.TimingInformation mockSessionTimingInfo;
+
+    @Mock
+    private IOUsage mockIOUsage;
+
+    @Mock
+    private TimingInformation mockTimingInfo;
+
     @BeforeEach
     public void init() {
         MockitoAnnotations.initMocks(this);
@@ -75,11 +87,13 @@ public class ResultRetrieverTest {
         Mockito.when(mockTerminalPage.values()).thenReturn(MOCK_EMPTY_VALUES);
         Mockito.when(mockFetchPage.page()).thenReturn(mockTerminalPage);
         Mockito.when(mockSession.sendFetchPage(MOCK_TXN_ID, MOCK_NEXT_PAGE_TOKEN)).thenReturn(mockFetchPage);
+        Mockito.when(mockFetchPage.consumedIOs()).thenReturn(mockConsumedIOs);
+        Mockito.when(mockFetchPage.timingInformation()).thenReturn(mockSessionTimingInfo);
     }
 
     private void initRetriever() {
         resultRetriever = new ResultRetriever(mockSession, mockPage, MOCK_TXN_ID, MOCK_READ_AHEAD,
-                                              ionSystem, null);
+                                              ionSystem, null, mockIOUsage, mockTimingInfo);
     }
 
     @Test

--- a/src/test/software/amazon/qldb/integrationtests/Constants.java
+++ b/src/test/software/amazon/qldb/integrationtests/Constants.java
@@ -25,7 +25,7 @@ public class Constants {
     public static final String MULTIPLE_DOCUMENT_VALUE_1 = "MultipleDocumentValue1";
     public static final String MULTIPLE_DOCUMENT_VALUE_2 = "MultipleDocumentValue2";
 
-    public static final int RETRY_LIMIT = 4;
+    public static final int RETRY_LIMIT = 5;
     public static final Long LEDGER_POLL_PERIOD_MS = 1000L;
     public static final int DEFAULT = -1;
 


### PR DESCRIPTION
Add execution statistics feature.
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request is to add programmatic access to some server-side statistics on individual statement executions.

To get some execution statistics, there are 2 new methods added to `Result` interface, :
- `IOUsage getConsumedIOs()` to obtain number of IOs for statement executions.
   * IOUsage provides `long getReadIOs()`
- `TimingInformation getTimingInformation()` to obtain information on processing time of an execution.
   * TimingInformation provides `long getProcessingTimeMilliseconds()`

These methods are stateful for `StreamResult`, meaning the statistics returned by them reflect the state at the time of method execution.