### PR TITLE
Don't override http client when maxConcurrentTransactions value is default when creating driver

### DIFF
--- a/src/test/software/amazon/qldb/QldbDriverImplTest.java
+++ b/src/test/software/amazon/qldb/QldbDriverImplTest.java
@@ -123,6 +123,16 @@ public class QldbDriverImplTest {
                                      .build());
     }
 
+    @Test
+    public void testBuildWithoutOverrideHttpClientWhenMaxConcurrentTransactionsIsDefault() {
+        QldbSessionClientBuilder mockSessionClientBuilder = mock(QldbSessionClientBuilder.class);
+        QldbDriver.builder()
+                  .sessionClientBuilder(mockSessionClientBuilder)
+                  .ledger(LEDGER)
+                  .build();
+        verify(mockSessionClientBuilder, never()).httpClient(any());
+    }
+
     /**
      * Happy case
      *


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->


## Description
<!--- Describe your changes in detail -->
There is no need to override the default `SdkHttpConfigurationOption.MAX_CONNECTIONS` attribute in driver `SdkHttpClient` if the `maxConcurrentTransactions` is also default value. This will allow user to provide customized `SdkHttpClient` using default `maxConcurrentTransactions` value.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] I have read the **CONTRIBUTING** document [Currently not accepting contributions]-->
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**


## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
