### PR TITLE
ops: add dependabot weekly updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+    commit-message:
+      prefix: "maven"
+    open-pull-requests-limit: 10
+    target-branch: "master"


### PR DESCRIPTION
Initialize Dependabot weekly PRs on the repository to ensure our upstream dependencies are up to date.

- [x] I confirm that this pull request can be released under the Apache 2 license
