### PR TITLE
Add short SHA to ledger suffix in test actions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Build with Maven
       run: |
         GITHUB_SHA_SHORT=$(git rev-parse --short $GITHUB_SHA)
-        mvn -B package --file pom.xml -D region=us-east-2 -D ledgerSuffix=${{ matrix.java}}-${{ matrix.os }}-$GITHUB_SHA_SHORT
+        mvn -B package --file pom.xml -D region=us-east-2 -D ledgerSuffix=-${{ strategy.job-index }}-$GITHUB_SHA_SHORT
     - name: Upload code coverage
       run: bash <(curl -s https://codecov.io/bash) -t ${{ secrets.CODECOV_TOKEN }}
       shell: bash

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -35,6 +35,7 @@ jobs:
       run: |
         GITHUB_SHA_SHORT=$(git rev-parse --short $GITHUB_SHA)
         mvn -B package --file pom.xml -D region=us-east-2 -D ledgerSuffix=-${{ strategy.job-index }}-$GITHUB_SHA_SHORT
+      shell: bash
     - name: Upload code coverage
       run: bash <(curl -s https://codecov.io/bash) -t ${{ secrets.CODECOV_TOKEN }}
       shell: bash

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -32,7 +32,9 @@ jobs:
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws-region: us-east-1
     - name: Build with Maven
-      run: mvn -B package --file pom.xml -D region=us-east-2 -D ledgerSuffix=${{ matrix.java}}-${{ matrix.os }}
+      run: |
+        GITHUB_SHA_SHORT=$(git rev-parse --short $GITHUB_SHA)
+        mvn -B package --file pom.xml -D region=us-east-2 -D ledgerSuffix=${{ matrix.java}}-${{ matrix.os }}-$GITHUB_SHA_SHORT
     - name: Upload code coverage
       run: bash <(curl -s https://codecov.io/bash) -t ${{ secrets.CODECOV_TOKEN }}
       shell: bash


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR adds the short form of the git SHA to the ledger suffix for test actions. Additionally, I replaced the Java version and OS in the ledger suffix with the job index in order to keep the generated ledger name under the 32-character limit.

## Motivation and Context
The current Github workflows run integration tests which create, modify, and delete real QLDB ledgers. To prevent conflicts within workflow runs, the created ledgers are suffixed with the OS and Java version under test. However, when multiple workflows are running at the same time (which is frequent after a Dependabot run), it is possible for two or more workflows to run integration tests with the same ledger name, resulting in inconsistent behavior and test failures. This can be dealt with by re-running workflows one at a time, but is time consuming. 

## Testing
This is just a change to Github actions, so no testing was done prior to creating the PR. As part of this PR, I will verify that the ledgers created during the testing workflows have the short SHA suffix as expected

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

(Neither, this is a change to github actions)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] I have read the **CONTRIBUTING** document [Currently not accepting contributions]-->
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**


## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
