### PR TITLE
actions: use OIDC aws credentials

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -9,6 +9,10 @@ on:
   pull_request:
     branches: [ master]
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}
@@ -28,9 +32,8 @@ jobs:
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws-region: us-east-1
+        role-to-assume: arn:aws:iam::264319671630:role/GitHubActionsOidc
     - name: Build with Maven
       run: |
         GITHUB_SHA_SHORT=$(git rev-parse --short $GITHUB_SHA)


### PR DESCRIPTION
https://github.com/awslabs/amazon-qldb-driver-nodejs/pull/246

- [x] I confirm that this pull request can be released under the Apache 2 license
